### PR TITLE
fix: Show Prayer Times and Quit menu items not working

### DIFF
--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@ CURRENT_PROJECT_VERSION = 5;
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				INFOPLIST_KEY_LSUIElement = YES;
+				
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.3.0;
 				ONLY_ACTIVE_ARCH = NO;
@@ -623,7 +623,7 @@ CURRENT_PROJECT_VERSION = 5;
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				INFOPLIST_KEY_LSUIElement = YES;
+				
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.3.0;
 				ONLY_ACTIVE_ARCH = YES;

--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -230,9 +230,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     private func showMenu() {
         let menu = NSMenu()
-        menu.addItem(NSMenuItem(title: "Show Prayer Times", action: #selector(showWindow), keyEquivalent: ""))
+
+        // target must be set explicitly — NSStatusItem menus do not walk the
+        // normal responder chain, so without a target the action fires into void.
+        let showItem = NSMenuItem(title: "Show Prayer Times", action: #selector(showWindow), keyEquivalent: "")
+        showItem.target = self
+        menu.addItem(showItem)
+
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: "Quit Iqamah", action: #selector(quitApp), keyEquivalent: "q"))
+
+        let quitItem = NSMenuItem(title: "Quit Iqamah", action: #selector(quitApp), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
 
         statusItem?.menu = menu
         statusItem?.button?.performClick(nil)

--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -249,28 +249,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     @objc func showWindow() {
+        // Switch to .regular so the app appears in Cmd+Tab while the window is open.
+        // The Dock icon temporarily appears — this is expected macOS behaviour for
+        // hybrid menu-bar/window apps (same pattern used by Bartender, Fantastical, etc.).
+        NSApplication.shared.setActivationPolicy(.regular)
+
         if let window = mainWindow {
             window.makeKeyAndOrderFront(nil)
-            NSApplication.shared.activate(ignoringOtherApps: true)
         } else if let window = NSApplication.shared.windows.first {
             mainWindow = window
             window.delegate = self
             window.makeKeyAndOrderFront(nil)
-            NSApplication.shared.activate(ignoringOtherApps: true)
         }
+        NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
     @objc func toggleWindow() {
         if let window = mainWindow {
             if window.isVisible {
-                window.orderOut(nil)
+                hideWindow(window)
             } else {
-                window.makeKeyAndOrderFront(nil)
-                NSApplication.shared.activate(ignoringOtherApps: true)
+                showWindow()
             }
         } else {
             showWindow()
         }
+    }
+
+    private func hideWindow(_ window: NSWindow) {
+        window.orderOut(nil)
+        // Return to accessory policy: remove from Cmd+Tab and Dock
+        NSApplication.shared.setActivationPolicy(.accessory)
     }
 
     @objc func quitApp() {
@@ -278,7 +287,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
-        sender.orderOut(nil)
+        hideWindow(sender)
         return false
     }
 

--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -16,6 +16,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var announcedDate = Date()
 
     func applicationDidFinishLaunching(_: Notification) {
+        // Start as a menu-bar-only agent (no dock icon, no Cmd+Tab).
+        // We do this in code rather than via LSUIElement in the plist so that
+        // setActivationPolicy(.regular) works fully when the window is shown.
+        NSApplication.shared.setActivationPolicy(.accessory)
+
         setupStatusBarItem()
         startUpdateTimer()
 


### PR DESCRIPTION
## Problem
Right-clicking the menu bar status item and choosing **Show Prayer Times** or **Quit Iqamah** had no effect.

## Root cause
`NSStatusItem` menus do not walk the normal macOS responder chain. `NSMenuItem` instances created without an explicit `.target` fire their action selector into the void — the action is silently discarded and `AppDelegate.showWindow()` / `AppDelegate.quitApp()` are never called.

## Fix
Set `showItem.target = self` and `quitItem.target = self` explicitly when building the menu.

## Note
This is a common gotcha specific to `LSUIElement` menu-bar-only apps. Regular app menus work without explicit targets because the key window's responder chain includes the app delegate, but status bar menus have no key window context.