### PR TITLE
feat: Option B secondary toolbar + light mode adaptive colours

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -1435,3 +1435,38 @@ Without this file, App Store Connect will reject the binary at upload with: *"IT
 ---
 
 **Last Updated:** 2026-04-30 (Previous UI review session + Adhaan sound feature session)
+
+---
+
+## Bug Fixes — 2026-05-01 to 2026-05-03 (Post-MVP Session)
+
+### Fixed
+
+**BUG-0035: Right-click status bar menu items had no effect**
+
+**Severity:** High  
+**Status:** ✅ Fixed — PR #35 merged  
+**Root cause:** `NSMenuItem` without an explicit `.target` in a status bar menu silently discards its action. The `NSStatusItem` menu has no responder chain context, unlike normal app menus which walk from the key window up to `NSApp` and `AppDelegate`. Both "Show Prayer Times" and "Quit Iqamah" were firing into void.  
+**Fix:** `showItem.target = self` and `quitItem.target = self` in `AppDelegate.showMenu()`.
+
+---
+
+**BUG-0036: App did not appear in Cmd+Tab switcher when main window was open**
+
+**Severity:** High  
+**Status:** ✅ Fixed — PR #35 merged  
+**Root cause:** `INFOPLIST_KEY_LSUIElement = YES` in the Xcode build settings is a process-level OS flag set before the app launches. It permanently marks the process as an agent, meaning `NSApp.setActivationPolicy(.regular)` calls at runtime are silently ignored for Cmd+Tab registration.  
+**Fix:** Removed `INFOPLIST_KEY_LSUIElement` from both Debug and Release build configs. Added `NSApplication.shared.setActivationPolicy(.accessory)` in `applicationDidFinishLaunching` for identical startup behaviour. The OS now fully honours `.regular` / `.accessory` transitions: window opens → `.regular` (Cmd+Tab visible, dock icon); window closes → `.accessory` (hidden).
+
+---
+
+**BUG-0037: UI design — header too dense, 7 competing elements**
+
+**Severity:** Low (UX)  
+**Status:** ✅ Fixed — PR open (`feat/option-b-secondary-toolbar-light-mode`)  
+**Root cause:** Primary header contained icon + wordmark + city + full method name + mute + Qiblah + settings + about — 7 interactive/informational elements with no visual hierarchy.  
+**Fix:** Option B design — header reduced to icon + wordmark + city + abbreviated method + mute. Secondary toolbar (Qiblah / Settings / About) below, Hijri date right-aligned in toolbar, Gregorian date standalone.
+
+---
+
+**Last Updated:** 2026-05-03

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -789,3 +789,41 @@ All features implemented and Release build succeeds with zero errors.
 
 **Last Updated:** 2026-04-30 (EPIC-0007 Adhaan sounds added; App Store submission checklist added)
 
+
+---
+
+## EPIC-0008: Post-MVP Bug Fixes & UX Improvements (2026-05-01 – 2026-05-03)
+
+**Status:** 🟡 In Progress
+
+---
+
+### US-0033 — Menu bar agent stability
+
+**Status:** ✅ Implemented (merged PR #35)
+
+- **BUG:** Right-click → "Show Prayer Times" and "Quit Iqamah" had no effect — `NSMenuItem` without `.target` in a status bar menu silently discards its action selector (no responder chain in status bar context).  
+- **FIX:** Set `showItem.target = self` and `quitItem.target = self` explicitly.
+
+- **BUG:** App did not appear in Cmd+Tab switcher when main window was open — `LSUIElement = YES` in Info.plist is a process-level OS flag that prevents `setActivationPolicy(.regular)` from fully registering the app in the Cmd+Tab switcher at runtime.  
+- **FIX:** Removed `INFOPLIST_KEY_LSUIElement` from both build configs; call `setActivationPolicy(.accessory)` in `applicationDidFinishLaunching` instead. App now toggles `.regular` (window open) / `.accessory` (window closed) seamlessly.
+
+---
+
+### US-0034 — UI Design Refresh: Option B secondary toolbar + light mode
+
+**Status:** 🟡 In Progress (PR open, CI running)
+
+**Acceptance Criteria:**
+- [x] Primary header trimmed to: app icon + "Iqamah" wordmark + city name + abbreviated method + mute button (4 elements vs. 7)
+- [x] Secondary toolbar below header contains: Qiblah / Settings / About as flat hover-highlight buttons (macOS toolbar convention)
+- [x] Hijri date moved into secondary toolbar right-aligned
+- [x] Gregorian date stands alone as single-line `subheadline.bold()`
+- [x] `CalculationMethod.shortName` computed property for abbreviated display (ISNA, MWL, Egyptian, etc.)
+- [x] `SecondaryToolbarButton` component: SF symbol + label, no border, hover background via semantic `quaternaryLabelColor`
+- [x] Shadow uses `Color.primary.opacity()` — adapts light/dark automatically
+- [ ] Full light mode pass on remaining hardcoded dark values (future follow-up)
+
+---
+
+**Last Updated:** 2026-05-03

--- a/iqamah/Models/CalculationMethod.swift
+++ b/iqamah/Models/CalculationMethod.swift
@@ -27,6 +27,18 @@ enum CalculationMethod: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Abbreviated name suitable for constrained UI (header toolbar).
+    var shortName: String {
+        switch self {
+        case .muslimWorldLeague: "MWL"
+        case .isna: "ISNA"
+        case .egypt: "Egyptian"
+        case .ummAlQura: "Umm Al-Qura"
+        case .karachi: "Karachi"
+        case .tehran: "Tehran"
+        }
+    }
+
     var fajrAngle: Double {
         switch self {
         case .muslimWorldLeague:

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -23,47 +23,41 @@ struct PrayerTimesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header with app branding, location and settings
-            HStack(spacing: 14) {
-                // App icon and title
-                HStack(spacing: 12) {
-                    // Use the compiled app icon asset — crisp at any size
-                    Image(nsImage: NSImage(named: NSImage.applicationIconName) ?? NSImage())
-                        .resizable()
-                        .frame(width: 36, height: 36)
-                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                        .shadow(color: Color.black.opacity(0.12), radius: 3, x: 0, y: 1)
+            // ── Primary header: brand + location + mute only ─────────
+            HStack(spacing: 12) {
+                Image(nsImage: NSImage(named: NSImage.applicationIconName) ?? NSImage())
+                    .resizable()
+                    .frame(width: 32, height: 32)
+                    .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                    .shadow(color: Color.primary.opacity(0.10), radius: 3, x: 0, y: 1)
 
-                    Text("Iqamah")
-                        .font(.system(size: titleFontSize, weight: .bold, design: .serif))
-                        .foregroundStyle(
-                            LinearGradient(
-                                colors: [
-                                    Color(red: 0.95, green: 0.76, blue: 0.06),
-                                    Color(red: 0.85, green: 0.65, blue: 0.13),
-                                ],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
+                Text("Iqamah")
+                    .font(.system(size: titleFontSize, weight: .bold, design: .serif))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [
+                                Color(red: 0.95, green: 0.76, blue: 0.06),
+                                Color(red: 0.85, green: 0.65, blue: 0.13),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
                         )
-                }
+                    )
 
-                // City and method — BUG-0029: lineLimit + scale prevents overflow at large text sizes
-                VStack(alignment: .leading, spacing: 3) {
+                VStack(alignment: .leading, spacing: 2) {
                     Text(city.name)
-                        .font(.body.weight(.semibold))
+                        .font(.subheadline.weight(.semibold))
                         .lineLimit(1)
-                        .minimumScaleFactor(0.8)
-                    Text(calculationMethod.displayName)
-                        .font(.caption.weight(.medium))
+                        .minimumScaleFactor(0.85)
+                    Text(calculationMethod.shortName)
+                        .font(.caption2.weight(.medium))
                         .foregroundColor(.secondary)
                         .lineLimit(1)
-                        .minimumScaleFactor(0.75)
                 }
 
                 Spacer()
 
-                // Global Adhaan mute toggle
+                // Mute — the one action important enough for the primary header
                 Button(action: { AdhaaanPlayer.shared.toggleMute() }) {
                     Image(systemName: AdhaaanPlayer.shared.isMuted
                         ? "speaker.slash.fill" : "speaker.wave.2.fill")
@@ -74,59 +68,50 @@ struct PrayerTimesView: View {
                 .buttonStyle(.plain)
                 .help(AdhaaanPlayer.shared.isMuted ? "Unmute Adhaan" : "Mute Adhaan")
                 .accessibilityLabel(AdhaaanPlayer.shared.isMuted ? "Adhaan muted — tap to unmute" : "Adhaan on — tap to mute")
-
-                // Qiblah button (AC-0135: labelled so purpose is clear)
-                Button(action: { showQiblah = true }) {
-                    VStack(spacing: 2) {
-                        PrayerMatIcon(size: 20)
-                        Text("Qiblah")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                .buttonStyle(.plain)
-                .help("Qiblah Direction")
-                .accessibilityLabel("Show Qiblah direction")
-                .accessibilityHint("Opens compass showing direction to Ka'bah in Makkah")
-
-                // Settings button — opens sheet, does not reset data
-                Button(action: { showSettings = true }) {
-                    Image(systemName: "gearshape.fill")
-                        .font(.title3)
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Settings")
-                .accessibilityLabel("Open settings")
-                .accessibilityHint("Change city, calculation method, or display options without losing your adjustments")
-
-                // About button
-                Button(action: { showAbout = true }) {
-                    Image(systemName: "info.circle")
-                        .font(.title3)
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .help("About Iqamah")
-                .accessibilityLabel("About Iqamah")
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 50)
-            .padding(.bottom, 18)
+            .padding(.horizontal, 22)
+            .padding(.top, 46)
+            .padding(.bottom, 10)
+
+            // ── Secondary toolbar: navigation actions + Hijri date ───
+            HStack(spacing: 0) {
+                SecondaryToolbarButton(
+                    label: "Qiblah",
+                    systemImage: "location.north.line.fill",
+                    action: { showQiblah = true }
+                )
+                .accessibilityLabel("Show Qiblah direction")
+
+                SecondaryToolbarButton(
+                    label: "Settings",
+                    systemImage: "gearshape",
+                    action: { showSettings = true }
+                )
+                .accessibilityLabel("Open settings")
+
+                SecondaryToolbarButton(
+                    label: "About",
+                    systemImage: "info.circle",
+                    action: { showAbout = true }
+                )
+                .accessibilityLabel("About Iqamah")
+
+                Spacer()
+
+                // Hijri date lives here — frees the date block below for Gregorian only
+                Text(currentDate.formattedHijriDate())
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.trailing, 16)
+            }
+            .background(Color(nsColor: .windowBackgroundColor))
 
             Divider()
-                .padding(.horizontal, 24)
 
-            // Date display
-            VStack(spacing: 5) {
-                Text(currentDate.formattedGregorianDate())
-                    .font(.body.bold())
-
-                Text(currentDate.formattedHijriDate())
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
-            .padding(.vertical, 18)
+            // Date display — Gregorian only, now cleaner
+            Text(currentDate.formattedGregorianDate())
+                .font(.subheadline.bold())
+                .padding(.vertical, 12)
 
             // Prayer times table
             if let prayerTimes {
@@ -575,5 +560,39 @@ struct PrayerTimeRow: View {
         default:
             "clock.fill"
         }
+    }
+}
+
+// MARK: - Secondary toolbar button
+
+/// Flat toolbar-style button used in the secondary bar below the primary header.
+/// Matches macOS convention: no border, subtle background on hover only.
+private struct SecondaryToolbarButton: View {
+    let label: String
+    let systemImage: String
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 12, weight: .medium))
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .foregroundColor(isHovering ? .primary : .secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isHovering
+                        ? Color(nsColor: .quaternaryLabelColor).opacity(0.5)
+                        : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
     }
 }


### PR DESCRIPTION
## What
Implements the design review recommendation: Option B header layout with secondary toolbar, plus light-mode-ready adaptive colours.

## Changes

**PrayerTimesView — Option B header:**
- Primary header: icon + Iqamah wordmark + city + abbreviated method name + mute only (4 elements, down from 7)
- New secondary toolbar: Qiblah / Settings / About as flat hover-highlight buttons (standard macOS convention — no border, subtle background on hover)
- Hijri date moved to right side of secondary toolbar
- Gregorian date stands alone as a clean single line below

**CalculationMethod — `shortName`:**
- New computed property for abbreviated display: ISNA, MWL, Egyptian, Umm Al-Qura, Karachi, Tehran

**SecondaryToolbarButton — new component:**
- SF symbol + label, plain style, hover via `Color(nsColor: .quaternaryLabelColor)`
- Foreground switches primary ↔ secondary on hover for clear affordance

**Light mode adaptive colours:**
- Shadow changed from `Color.black.opacity()` → `Color.primary.opacity()` — adapts automatically
- Toolbar background uses `Color(nsColor: .windowBackgroundColor)` — semantic

**Docs:**
- BUG-0035/0036/0037 added to BUGS.md
- EPIC-0008 + US-0033/US-0034 added to RELEASE_PLAN.md