### PR TITLE
ci: path-filter cities.json validation to dedicated workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,6 @@ env:
 jobs:
 
   # ──────────────────────────────────────────────────────────────────────────
-  # 0. DATA VALIDATION — cities.json schema check
-  # ──────────────────────────────────────────────────────────────────────────
-  validate_cities:
-    name: Validate cities.json
-    runs-on: ubuntu-latest   # no Xcode needed — pure Python
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run schema validation
-        run: python3 scripts/validate_cities.py
-
-  # ──────────────────────────────────────────────────────────────────────────
   # 1. LINT — SwiftLint style + rule enforcement
   # ──────────────────────────────────────────────────────────────────────────
   lint:

--- a/.github/workflows/validate-cities.yml
+++ b/.github/workflows/validate-cities.yml
@@ -1,0 +1,22 @@
+name: Validate cities.json
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'iqamah/Resources/cities.json'
+      - 'scripts/validate_cities.py'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'iqamah/Resources/cities.json'
+      - 'scripts/validate_cities.py'
+
+jobs:
+  validate_cities:
+    name: Validate cities.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run schema validation
+        run: python3 scripts/validate_cities.py


### PR DESCRIPTION
## Summary
- Moves `validate_cities` job from `ci.yml` into a new `validate-cities.yml` workflow
- New workflow runs only on PRs/pushes that touch `iqamah/Resources/cities.json` or `scripts/validate_cities.py`
- Reduces unnecessary CI minutes on PRs that don't touch the cities data

## Test plan
- [x] `python3 scripts/validate_cities.py` exits 0 locally
- [x] `ci.yml` is valid YAML after removal

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)