### PR TITLE
test: add prayer time accuracy regression test suite

### DIFF
--- a/Tests/PrayerAccuracyRegressionTests.swift
+++ b/Tests/PrayerAccuracyRegressionTests.swift
@@ -1,0 +1,139 @@
+import Testing
+import Foundation
+import CoreLocation
+
+@Suite("Prayer Time Accuracy Regression Tests")
+struct PrayerAccuracyRegressionTests {
+    private static func referenceDate(in tz: TimeZone) -> Date {
+        var c = DateComponents()
+        c.timeZone = tz
+        c.year = 2024
+        c.month = 1
+        c.day = 15
+        c.hour = 12
+        c.minute = 0
+        c.second = 0
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private func hm(_ date: Date, in tz: TimeZone) -> (Int, Int) {
+        let comps = Calendar(identifier: .gregorian)
+            .dateComponents(in: tz, from: date)
+        return (comps.hour!, comps.minute!)
+    }
+
+    private func assertWithin3Min(
+        _ actual: Date,
+        expected: (h: Int, m: Int),
+        in tz: TimeZone,
+        label: String,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        let (ah, am) = hm(actual, in: tz)
+        let actualMin = ah * 60 + am
+        let expectedMin = expected.h * 60 + expected.m
+        let diff = abs(actualMin - expectedMin)
+        let msg: Comment = "\(label): expected \(expected.h):\(String(format: "%02d", expected.m)), got \(ah):\(String(format: "%02d", am)) (diff \(diff) min)"
+        #expect(diff <= 3, msg, sourceLocation: sourceLocation)
+    }
+
+    // MARK: - Makkah
+
+    @Test("Makkah (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func makkahAccuracy() throws {
+        let tz = try #require(TimeZone(identifier: "Asia/Riyadh"))
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: 21.4225, longitude: 39.8262),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr, expected: (5, 42), in: tz, label: "Makkah Fajr")
+        assertWithin3Min(times.dhuhr, expected: (12, 30), in: tz, label: "Makkah Dhuhr")
+        assertWithin3Min(times.asr, expected: (15, 36), in: tz, label: "Makkah Asr")
+        assertWithin3Min(times.maghrib, expected: (17, 58), in: tz, label: "Makkah Maghrib")
+        assertWithin3Min(times.isha, expected: (19, 12), in: tz, label: "Makkah Isha")
+    }
+
+    // MARK: - New York
+
+    @Test("New York (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func newYorkAccuracy() throws {
+        let tz = try #require(TimeZone(identifier: "America/New_York"))
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.006),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr, expected: (5, 41), in: tz, label: "New York Fajr")
+        assertWithin3Min(times.dhuhr, expected: (12, 6), in: tz, label: "New York Dhuhr")
+        assertWithin3Min(times.asr, expected: (14, 32), in: tz, label: "New York Asr")
+        assertWithin3Min(times.maghrib, expected: (16, 51), in: tz, label: "New York Maghrib")
+        assertWithin3Min(times.isha, expected: (18, 23), in: tz, label: "New York Isha")
+    }
+
+    // MARK: - London
+
+    @Test("London (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func londonAccuracy() throws {
+        let tz = try #require(TimeZone(identifier: "Europe/London"))
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: 51.5074, longitude: -0.1278),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr, expected: (5, 59), in: tz, label: "London Fajr")
+        assertWithin3Min(times.dhuhr, expected: (12, 10), in: tz, label: "London Dhuhr")
+        assertWithin3Min(times.asr, expected: (13, 59), in: tz, label: "London Asr")
+        assertWithin3Min(times.maghrib, expected: (16, 18), in: tz, label: "London Maghrib")
+        assertWithin3Min(times.isha, expected: (18, 12), in: tz, label: "London Isha")
+    }
+
+    // MARK: - Jakarta
+
+    @Test("Jakarta (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func jakartaAccuracy() throws {
+        let tz = try #require(TimeZone(identifier: "Asia/Jakarta"))
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: -6.2088, longitude: 106.8456),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr, expected: (4, 33), in: tz, label: "Jakarta Fajr")
+        assertWithin3Min(times.dhuhr, expected: (12, 2), in: tz, label: "Jakarta Dhuhr")
+        assertWithin3Min(times.asr, expected: (15, 26), in: tz, label: "Jakarta Asr")
+        assertWithin3Min(times.maghrib, expected: (18, 14), in: tz, label: "Jakarta Maghrib")
+        assertWithin3Min(times.isha, expected: (19, 25), in: tz, label: "Jakarta Isha")
+    }
+
+    // MARK: - Toronto
+
+    @Test("Toronto (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func torontoAccuracy() throws {
+        let tz = try #require(TimeZone(identifier: "America/Toronto"))
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: 43.6532, longitude: -79.3832),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr, expected: (6, 6), in: tz, label: "Toronto Fajr")
+        assertWithin3Min(times.dhuhr, expected: (12, 27), in: tz, label: "Toronto Dhuhr")
+        assertWithin3Min(times.asr, expected: (14, 45), in: tz, label: "Toronto Asr")
+        assertWithin3Min(times.maghrib, expected: (17, 5), in: tz, label: "Toronto Maghrib")
+        assertWithin3Min(times.isha, expected: (18, 43), in: tz, label: "Toronto Isha")
+    }
+}

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		EE000000000000000000100C /* PrayerCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE000000000000000000100B /* PrayerCalculatorTests.swift */; };
 		EE000000000000000000100E /* IqamahModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE000000000000000000100D /* IqamahModelTests.swift */; };
 		EE0000000000000000001010 /* IntegrationAndEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE000000000000000000100F /* IntegrationAndEdgeCaseTests.swift */; };
+		EE0000000000000000001012 /* PrayerAccuracyRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0000000000000000001011 /* PrayerAccuracyRegressionTests.swift */; };
 		EE0000000000000000002000 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000013 /* Location.swift */; };
 		EE0000000000000000002001 /* CalculationMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000014 /* CalculationMethod.swift */; };
 		EE0000000000000000002002 /* PrayerTimes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000015 /* PrayerTimes.swift */; };
@@ -125,6 +126,7 @@
 		EE000000000000000000100B /* PrayerCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerCalculatorTests.swift; sourceTree = "<group>"; };
 		EE000000000000000000100D /* IqamahModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IqamahModelTests.swift; sourceTree = "<group>"; };
 		EE000000000000000000100F /* IntegrationAndEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationAndEdgeCaseTests.swift; sourceTree = "<group>"; };
+		EE0000000000000000001011 /* PrayerAccuracyRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerAccuracyRegressionTests.swift; sourceTree = "<group>"; };
 		FF000000000000000000AA01 /* Adhaan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Adhaan.swift; sourceTree = "<group>"; };
 		FF000000000000000000AA02 /* AdhaaanPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdhaaanPlayer.swift; sourceTree = "<group>"; };
 		BN000000000000000000AA01 /* AdhaanBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdhaanBannerView.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				EE000000000000000000100B /* PrayerCalculatorTests.swift */,
 				EE000000000000000000100D /* IqamahModelTests.swift */,
 				EE000000000000000000100F /* IntegrationAndEdgeCaseTests.swift */,
+				EE0000000000000000001011 /* PrayerAccuracyRegressionTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				EE000000000000000000100C /* PrayerCalculatorTests.swift in Sources */,
 				EE000000000000000000100E /* IqamahModelTests.swift in Sources */,
 				EE0000000000000000001010 /* IntegrationAndEdgeCaseTests.swift in Sources */,
+				EE0000000000000000001012 /* PrayerAccuracyRegressionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary
- Adds `Tests/PrayerAccuracyRegressionTests.swift` to the `iqamahTests` target
- 5 reference cities × 5 prayers = 25 assertions on a fixed date (2024-01-15, MWL, Standard Asr)
- Tolerance: ±3 minutes per prayer (guards against algorithmic regression)
- All `DateComponents` include `timeZone` explicitly to prevent UTC drift on CI runners
- `project.pbxproj` updated with new file reference and build file entries

**Note on reference values:** Expected times are derived from the app's own NOAA-based algorithm, cross-verified against pyephem (a high-precision ephemeris library). IslamicFinder's values differ by up to ~20 min for Fajr/Isha, because IslamicFinder uses an effective depression angle of ~15° rather than the MWL-official 18°. The app's transit, Asr, and Maghrib values are accurate to ±1 min vs pyephem.

## Test plan
- [x] All 5 test cases pass locally (10/10 runs)
- [ ] CI test job passes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)