### PR TITLE
docs: record resolution of issues #4, #5, #6

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -14,6 +14,25 @@ All bugs and defects tracked here with BUG-XXXX identifiers and status.
 
 ---
 
+## Resolved (sprint 2026-05-03)
+
+**BUG-CI-005: cities.json validation not path-filtered in CI**
+- **Severity:** Low / maintenance
+- **Resolution:** Added `validate-cities.yml` workflow with `paths:` filter on `iqamah/Resources/cities.json` (PR #37)
+- **Resolved:** 2026-05-03
+
+**BUG-CI-006: File size guard checked repo files, not .app bundle**
+- **Severity:** Medium
+- **Resolution:** Replaced `file-size` CI job with Release build + `du -sm` bundle check (50 MB limit) (PR #38)
+- **Resolved:** 2026-05-03
+
+**BUG-TEST-004: No prayer time accuracy regression tests**
+- **Severity:** High
+- **Resolution:** Added `PrayerAccuracyRegressionTests.swift` — 5 cities × 5 prayers on 2024-01-15, ±3 min tolerance (PR #39)
+- **Resolved:** 2026-05-03
+
+---
+
 ## Bugs by Status
 
 ### Open

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -310,8 +310,13 @@ Detailed release plan defining MVP and subsequent milestones. Contains Epics, Us
 **Description:** Ensure all features meet quality standards with comprehensive testing, accessibility compliance, and performance validation.
 
 **Release Target:** MVP v1.0.0  
-**Status:** 🔴 Not Started  
+**Status:** 🟡 In Progress  
 **Dependencies:** EPIC-0001, EPIC-0002, EPIC-0003
+
+**CI/QA completed 2026-05-03:**
+- Issue #5 — cities.json schema validation CI job with `paths:` filter (PR #37)
+- Issue #6 — Release .app bundle size budget check (50 MB limit) in CI (PR #38)
+- Issue #4 — Prayer time accuracy regression test suite: 5 cities × 5 prayers, ±3 min tolerance (PR #39)
 
 ### User Stories in EPIC-0004
 


### PR DESCRIPTION
## Summary
- `docs/BUGS.md`: adds Resolved section with BUG-CI-005, BUG-CI-006, BUG-TEST-004
- `docs/RELEASE_PLAN.md`: marks EPIC-0004 as In Progress and records the three CI/QA completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)