### PR TITLE
fix: remove invalid network.client entitlement (App Store rejection BUG-0051)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -1774,3 +1774,33 @@ Check `AVAudioPlayer.play()` return value and handle `false` (failure to start).
 ---
 
 **Last Updated:** 2026-05-05 (App Store submission complete; BUG-0049, BUG-0050 logged)
+
+---
+
+## App Store Rejection — 2026-05-05
+
+**BUG-0051: Invalid entitlement value causes App Store rejection (Guideline 2.4.5(i))**
+
+**Severity:** Critical (blocks App Store distribution)  
+**Discovered:** 2026-05-05 — App Store review rejection  
+**Status:** ✅ Fixed
+
+**Rejection message:**  
+> Guideline 2.4.5(i) - Performance  
+> The app incorrectly implements sandboxing, or it contains one or more entitlements with invalid values.  
+> `com.apple.security.network.client	False`
+
+**Root Cause:**  
+`iqamah.entitlements` contained `com.apple.security.network.client` set to `<false/>`. Entitlements are capability grants — a key's *presence* means "grant this capability". Setting a key to `<false/>` is contradictory and invalid. Apple's codesigning validator rejects it under Guideline 2.4.5(i).
+
+**Fix:**  
+Removed `com.apple.security.network.client` entirely. Iqamah makes no network requests and does not need this entitlement. The entitlements file now contains only two valid keys:
+- `com.apple.security.app-sandbox = true`
+- `com.apple.security.personal-information.location = true`
+
+**Next steps:**  
+Archive a new build and resubmit to App Store Connect.
+
+---
+
+**Last Updated:** 2026-05-05 (App Store rejection resolved — resubmit required)

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -1715,3 +1715,62 @@ _ = try City(name: "Test", countryCode: "XX", latitude: 91, longitude: 0, timezo
 ---
 
 **Last Updated:** 2026-05-05
+
+---
+
+## Milestone — 2026-05-05: App Store Submission
+
+Iqamah v1.0 submitted to App Store Connect for review.
+- Screenshots uploaded
+- Archive built from `develop` @ `747a5b2`
+- Bundle ID: `com.fablesoft.iqamah`, Team: `96Y29SP9JR`
+- BUG-0034 (App Store Connect registration) → **Resolved**
+
+---
+
+## New Bugs — 2026-05-05 (Xcode console log review)
+
+**BUG-0049: layoutSubtreeIfNeeded called during active layout pass in AdhaanBannerController**
+
+**Severity:** Low  
+**Discovered:** 2026-05-05 Xcode console  
+**Status:** Open
+
+**Description:**  
+`AdhaanBannerController.show()` calls `hosting.layoutSubtreeIfNeeded()` to measure the banner's fitting height, but this fires during an active layout cycle causing the warning "It's not legal to call -layoutSubtreeIfNeeded on a view which is already being laid out."
+
+**Code Location:** `iqamah/Services/AdhaanBannerController.swift` — size measurement block
+
+```swift
+// Problematic:
+hosting.frame = CGRect(x: 0, y: 0, width: bannerWidth, height: 1)
+hosting.layoutSubtreeIfNeeded()
+let fittingHeight = hosting.fittingSize.height
+
+// Fix: use fittingSize directly — it triggers layout internally without recursion
+let fittingHeight = hosting.fittingSize.height
+```
+
+**Priority:** Low — cosmetic console warning; adhaan banner still displays correctly
+
+---
+
+**BUG-0050: Audio queue timeout causes silent adhaan failure**
+
+**Severity:** Medium  
+**Discovered:** 2026-05-05 Xcode console  
+**Status:** Open
+
+**Description:**  
+Console logs show `AQMEIO timed out after 15s` followed by `MEDeviceStreamClient: client stopping after failed start: AudioQueueObject`. An audio queue was unable to start (audio subsystem busy or hardware unavailable). If this occurs at prayer time the adhaan plays silently with no user feedback.
+
+**Code Location:** `iqamah/Services/AdhaaanPlayer.swift` — `play()` / `preview()` methods
+
+**Recommended Fix:**  
+Check `AVAudioPlayer.play()` return value and handle `false` (failure to start). Show a visual fallback (e.g., banner still appears, mute icon pulses) so the user knows prayer time arrived even if audio failed.
+
+**Priority:** Medium — silent failure at prayer time is user-facing
+
+---
+
+**Last Updated:** 2026-05-05 (App Store submission complete; BUG-0049, BUG-0050 logged)

--- a/iqamah/iqamah.entitlements
+++ b/iqamah/iqamah.entitlements
@@ -6,7 +6,5 @@
 	<true/>
 	<key>com.apple.security.personal-information.location</key>
 	<true/>
-	<key>com.apple.security.network.client</key>
-	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
App Store rejected v1.0 build with Guideline 2.4.5(i): entitlement `com.apple.security.network.client` was set to `<false/>` which is invalid. Removed entirely — Iqamah makes no network requests.