### PR TITLE
feat(US-0044): WidgetKit Home/Lock Screen widget

### DIFF
--- a/IqamahWidget/Info.plist
+++ b/IqamahWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>

--- a/IqamahWidget/IqamahWidget.entitlements
+++ b/IqamahWidget/IqamahWidget.entitlements
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.personal-information.location</key>
-	<true/>
-	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.fablesoft.iqamah</string>

--- a/IqamahWidget/IqamahWidget.swift
+++ b/IqamahWidget/IqamahWidget.swift
@@ -1,0 +1,167 @@
+import IqamahCore
+import SwiftUI
+import WidgetKit
+
+// MARK: - Timeline entry
+
+struct PrayerEntry: TimelineEntry {
+    let date: Date
+    let nextPrayerName: String
+    let nextPrayerTime: Date
+    let cityName: String
+}
+
+// MARK: - Timeline provider
+
+struct PrayerTimelineProvider: TimelineProvider {
+    func placeholder(in _: Context) -> PrayerEntry {
+        PrayerEntry(
+            date: Date(),
+            nextPrayerName: "Dhuhr",
+            nextPrayerTime: Date().addingTimeInterval(3600),
+            cityName: "Makkah"
+        )
+    }
+
+    func getSnapshot(in _: Context, completion: @escaping (PrayerEntry) -> Void) {
+        completion(makeEntry(for: Date()))
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<PrayerEntry>) -> Void) {
+        let now = Date()
+        let entry = makeEntry(for: now)
+        // Refresh after next prayer time (or in 1 hour if no prayer found)
+        let nextRefresh = entry.nextPrayerTime > now ? entry.nextPrayerTime : now.addingTimeInterval(3600)
+        completion(Timeline(entries: [entry], policy: .after(nextRefresh)))
+    }
+
+    private func makeEntry(for date: Date) -> PrayerEntry {
+        let settings = SettingsManager.shared
+        guard let coord = settings.activeCoordinate,
+              let timezone = TimeZone(identifier: settings.activeTimezoneIdentifier)
+        else {
+            return PrayerEntry(date: date, nextPrayerName: "—", nextPrayerTime: date, cityName: "—")
+        }
+
+        let calc = PrayerCalculator(
+            coordinate: coord,
+            timezone: timezone,
+            method: settings.calculationMethod,
+            asrMethod: settings.asrMethod
+        )
+
+        // Find next upcoming prayer (today or tomorrow if all past)
+        for dayOffset in 0 ... 1 {
+            guard let day = Calendar.current.date(byAdding: .day, value: dayOffset, to: date),
+                  let times = try? calc.calculate(for: day)
+            else { continue }
+            if let next = times.prayers.first(where: { $0.time > date && $0.name != "Sunrise" }) {
+                return PrayerEntry(
+                    date: date,
+                    nextPrayerName: next.name,
+                    nextPrayerTime: next.time,
+                    cityName: settings.activeCityName
+                )
+            }
+        }
+
+        return PrayerEntry(date: date, nextPrayerName: "—", nextPrayerTime: date, cityName: "—")
+    }
+}
+
+// MARK: - Widget views
+
+struct IqamahWidgetView: View {
+    var entry: PrayerEntry
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallView
+        case .systemMedium:
+            mediumView
+        case .accessoryRectangular:
+            lockScreenView
+        default:
+            smallView
+        }
+    }
+
+    private var smallView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(entry.cityName)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer()
+            Text(entry.nextPrayerName)
+                .font(.title3.bold())
+            Text(entry.nextPrayerTime, style: .relative)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    private var mediumView: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(entry.cityName)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(entry.nextPrayerName)
+                    .font(.title2.bold())
+            }
+            Spacer()
+            VStack(alignment: .trailing) {
+                Text("in")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(entry.nextPrayerTime, style: .relative)
+                    .font(.title3.monospacedDigit().bold())
+                Text(entry.nextPrayerTime, style: .time)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    private var lockScreenView: some View {
+        HStack {
+            Text(entry.nextPrayerName)
+                .font(.headline)
+            Spacer()
+            Text(entry.nextPrayerTime, style: .relative)
+                .font(.caption.monospacedDigit())
+        }
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Widget configuration
+
+struct IqamahWidget: Widget {
+    let kind = "IqamahWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: PrayerTimelineProvider()) { entry in
+            IqamahWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Iqamah")
+        .description("Next prayer countdown for your location.")
+        .supportedFamilies([.systemSmall, .systemMedium, .accessoryRectangular])
+    }
+}
+
+// MARK: - Widget bundle
+
+@main
+struct IqamahWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        IqamahWidget()
+    }
+}

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
@@ -28,7 +28,12 @@ public enum AppAppearance: String, CaseIterable {
 }
 
 public class SettingsManager: ObservableObject {
-    public static let shared = SettingsManager()
+    private static let appGroupID = "group.com.fablesoft.iqamah"
+
+    public static let shared: SettingsManager = {
+        let suite = UserDefaults(suiteName: appGroupID) ?? .standard
+        return SettingsManager(userDefaults: suite)
+    }()
 
     private let defaults: UserDefaults
     private let kvs = NSUbiquitousKeyValueStore.default
@@ -286,6 +291,40 @@ public class SettingsManager: ObservableObject {
             object: kvs
         )
         kvs.synchronize()
+
+        migrateFromStandardDefaultsIfNeeded()
+    }
+
+    // MARK: - App Group migration
+
+    private func migrateFromStandardDefaultsIfNeeded() {
+        let migrationKey = "didMigrateToAppGroupV1"
+        // Skip if already migrated OR if the suite already has meaningful data
+        guard !defaults.bool(forKey: migrationKey),
+              defaults.dictionaryRepresentation().count <= 2
+        else {
+            defaults.set(true, forKey: migrationKey)
+            return
+        }
+        let std = UserDefaults.standard
+        // Only migrate if standard has setup data to copy
+        guard std.bool(forKey: "hasCompletedSetup") else {
+            defaults.set(true, forKey: migrationKey)
+            return
+        }
+        let keysToMigrate = [
+            "hasCompletedSetup", "selectedCityName", "selectedCityCountryCode",
+            "selectedCityLatitude", "selectedCityLongitude", "selectedCityTimezone",
+            "calculationMethod", "asrMethod", "prayerAdjustments", "use24HourTime",
+            "prayerAdhaanIds", "mutedPrayers", "uiScale", "appAppearance",
+            "locationSource", "gpsLocality", "gpsTimezone",
+        ]
+        for key in keysToMigrate {
+            if let value = std.object(forKey: key) {
+                defaults.set(value, forKey: key)
+            }
+        }
+        defaults.set(true, forKey: migrationKey)
     }
 
     // MARK: - iCloud KVS remote change handler

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		iOS000000000000000000000E /* SplashScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CAD56A2F23D3C800E1689F /* SplashScreenView.swift */; };
 		iOS000000000000000000000F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000001C /* Assets.xcassets */; };
 		iOS0000000000000000000010 /* IqamahCore in Frameworks */ = {isa = PBXBuildFile; productRef = iOS0000000000000000000020 /* IqamahCore */; };
+		WG000000000000000000021 /* IqamahWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = WG000000000000000000011 /* IqamahWidget.swift */; };
+		WG000000000000000000031 /* IqamahCore in Frameworks */ = {isa = PBXBuildFile; productRef = WG000000000000000000032 /* IqamahCore */; };
+		WG000000000000000000041 /* IqamahWidget.appex in PlugIns */ = {isa = PBXBuildFile; fileRef = WG000000000000000000042 /* IqamahWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +60,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = AA0000000000000000000040;
 			remoteInfo = iqamah;
+		};
+		WG000000000000000000051 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AA0000000000000000000050 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = WG000000000000000000001;
+			remoteInfo = IqamahWidget;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -119,6 +129,10 @@
 		iOS0000000000000000000013 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		iOS0000000000000000000014 /* iqamah-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "iqamah-iOS.entitlements"; sourceTree = "<group>"; };
 		iOS0000000000000000000015 /* iqamah-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iqamah-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		WG000000000000000000011 /* IqamahWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IqamahWidget.swift; sourceTree = "<group>"; };
+		WG000000000000000000012 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		WG000000000000000000013 /* IqamahWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IqamahWidget.entitlements; sourceTree = "<group>"; };
+		WG000000000000000000042 /* IqamahWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = IqamahWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -149,6 +163,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		WG000000000000000000062 /* Frameworks (Widget) */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				WG000000000000000000031 /* IqamahCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -157,6 +179,7 @@
 			children = (
 				944B0D7D2F6340DD00EC6A01 /* AGENTS.md */,
 				AA0000000000000000000031 /* iqamah */,
+				WG000000000000000000070 /* IqamahWidget */,
 				AA0000000000000000000032 /* Products */,
 		
 				9457D7C42F2BDF2D00549E92 /* AppIconView.swift */,
@@ -199,6 +222,7 @@
 				AA0000000000000000000010 /* iqamah.app */,
 				EE0000000000000000001001 /* iqamahTests.xctest */,
 				iOS0000000000000000000015 /* iqamah-iOS.app */,
+				WG000000000000000000042 /* IqamahWidget.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -275,6 +299,16 @@
 			path = iOS;
 			sourceTree = "<group>";
 		};
+		WG000000000000000000070 /* IqamahWidget */ = {
+			isa = PBXGroup;
+			children = (
+				WG000000000000000000011 /* IqamahWidget.swift */,
+				WG000000000000000000012 /* Info.plist */,
+				WG000000000000000000013 /* IqamahWidget.entitlements */,
+			);
+			path = IqamahWidget;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -326,10 +360,12 @@
 				iOS0000000000000000000042 /* Sources (iOS) */,
 				iOS0000000000000000000041 /* Frameworks (iOS) */,
 				iOS0000000000000000000043 /* Resources (iOS) */,
+				WG000000000000000000090 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				WG000000000000000000052 /* PBXTargetDependency */,
 			);
 			name = "iqamah-iOS";
 			packageProductDependencies = (
@@ -338,6 +374,26 @@
 			productName = "iqamah-iOS";
 			productReference = iOS0000000000000000000015 /* iqamah-iOS.app */;
 			productType = "com.apple.product-type.application";
+		};
+		WG000000000000000000001 /* IqamahWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = WG000000000000000000080 /* Build configuration list for PBXNativeTarget "IqamahWidget" */;
+			buildPhases = (
+				WG000000000000000000060 /* Sources (Widget) */,
+				WG000000000000000000062 /* Frameworks (Widget) */,
+				WG000000000000000000061 /* Resources (Widget) */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IqamahWidget;
+			packageProductDependencies = (
+				WG000000000000000000032 /* IqamahCore */,
+			);
+			productName = IqamahWidget;
+			productReference = WG000000000000000000042 /* IqamahWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -380,6 +436,7 @@
 				AA0000000000000000000040 /* iqamah */,
 				EE0000000000000000001000 /* iqamahTests */,
 				iOS0000000000000000000040 /* iqamah-iOS */,
+				WG000000000000000000001 /* IqamahWidget */,
 			);
 		};
 /* End PBXProject section */
@@ -407,6 +464,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				iOS000000000000000000000F /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		WG000000000000000000061 /* Resources (Widget) */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -468,13 +532,40 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		WG000000000000000000060 /* Sources (Widget) */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				WG000000000000000000021 /* IqamahWidget.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		WG000000000000000000090 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				WG000000000000000000041 /* IqamahWidget.appex in PlugIns */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		EE0000000000000000007002 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = AA0000000000000000000040 /* iqamah */;
 			targetProxy = EE0000000000000000007001 /* PBXContainerItemProxy */;
+		};
+		WG000000000000000000052 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = WG000000000000000000001 /* IqamahWidget */;
+			targetProxy = WG000000000000000000051 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -767,6 +858,60 @@
 			};
 			name = Release;
 		};
+		WG000000000000000000081 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = IqamahWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.widget;
+				PRODUCT_NAME = IqamahWidget;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.10;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		WG000000000000000000082 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = IqamahWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.widget;
+				PRODUCT_NAME = IqamahWidget;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.10;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -777,6 +922,7 @@
 		IC0000000000000000000002 /* IqamahCore */ = {isa = XCSwiftPackageProductDependency; package = IC0000000000000000000001 /* XCLocalSwiftPackageReference "Packages/IqamahCore" */; productName = IqamahCore; };
 		IC0000000000000000000004 /* IqamahCore */ = {isa = XCSwiftPackageProductDependency; package = IC0000000000000000000001 /* XCLocalSwiftPackageReference "Packages/IqamahCore" */; productName = IqamahCore; };
 		iOS0000000000000000000020 /* IqamahCore */ = {isa = XCSwiftPackageProductDependency; package = IC0000000000000000000001 /* XCLocalSwiftPackageReference "Packages/IqamahCore" */; productName = IqamahCore; };
+		WG000000000000000000032 /* IqamahCore */ = {isa = XCSwiftPackageProductDependency; package = IC0000000000000000000001 /* XCLocalSwiftPackageReference "Packages/IqamahCore" */; productName = IqamahCore; };
 /* End XCSwiftPackageProductDependency section */
 
 /* Begin XCConfigurationList section */
@@ -812,6 +958,15 @@
 			buildConfigurations = (
 				iOS0000000000000000000061 /* Debug */,
 				iOS0000000000000000000062 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		WG000000000000000000080 /* Build configuration list for PBXNativeTarget "IqamahWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				WG000000000000000000081 /* Debug */,
+				WG000000000000000000082 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iqamah.xcodeproj/xcshareddata/xcschemes/IqamahWidget.xcscheme
+++ b/iqamah.xcodeproj/xcshareddata/xcschemes/IqamahWidget.xcscheme
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WG000000000000000000001"
+               BuildableName = "IqamahWidget.appex"
+               BlueprintName = "IqamahWidget"
+               ReferencedContainer = "container:iqamah.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iqamah/iOS/iqamah-iOS.entitlements
+++ b/iqamah/iOS/iqamah-iOS.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.fablesoft.iqamah</string>
+	</array>
 </dict>
 </plist>

--- a/iqamah/iOS/iqamahApp_iOS.swift
+++ b/iqamah/iOS/iqamahApp_iOS.swift
@@ -1,5 +1,6 @@
 import IqamahCore
 import SwiftUI
+import WidgetKit
 
 @main
 struct IqamahiOSApp: App {
@@ -11,8 +12,8 @@ struct IqamahiOSApp: App {
             IOSRootView()
                 .environmentObject(settings)
                 // Reschedule when settings that affect prayer times change
-                .onChange(of: settings.calculationMethod) { _, _ in reschedule() }
-                .onChange(of: settings.asrMethod) { _, _ in reschedule() }
+                .onChange(of: settings.calculationMethod) { _, _ in reschedule(); reloadWidget() }
+                .onChange(of: settings.asrMethod) { _, _ in reschedule(); reloadWidget() }
                 .onChange(of: settings.enabledPrayers) { _, _ in reschedule() }
                 // Reschedule on each app-active to advance the 7-day window
                 .onChange(of: scenePhase) { _, phase in
@@ -23,5 +24,9 @@ struct IqamahiOSApp: App {
 
     private func reschedule() {
         Task { await NotificationScheduler.shared.rescheduleAll() }
+    }
+
+    private func reloadWidget() {
+        WidgetCenter.shared.reloadAllTimelines()
     }
 }


### PR DESCRIPTION
## Summary

- Adds `IqamahWidget` app extension target (WidgetKit) with three widget families: `.systemSmall`, `.systemMedium`, and `.accessoryRectangular` (Lock Screen)
- Shows next prayer name and live countdown; refreshes automatically after each prayer time passes
- Migrates `SettingsManager.shared` to `UserDefaults(suiteName: "group.com.fablesoft.iqamah")` (App Group) so the widget can read the same settings as the app
- Includes a one-time migration from `.standard` defaults for existing users
- `WidgetCenter.shared.reloadAllTimelines()` called from `iqamah-iOS` whenever calculation method or Asr method changes

## Build results

- macOS (`iqamah`): BUILD SUCCEEDED
- iOS (`iqamah-iOS`): BUILD SUCCEEDED (widget embedded as PlugIn)
- Widget (`IqamahWidget`): BUILD SUCCEEDED
- IqamahCore `swift test`: 140/140 passed

## Test plan

- [ ] Build and run `iqamah-iOS` on an iPhone 17 Pro Max simulator
- [ ] Add the Iqamah widget to the Home Screen (small and medium sizes)
- [ ] Add the Iqamah widget to the Lock Screen (rectangular)
- [ ] Verify the widget shows the next prayer name and countdown
- [ ] Change the calculation method in the app; confirm the widget timeline refreshes
- [ ] Verify existing users' settings survive the App Group migration (city, method, adjustments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)