### PR TITLE
fix: desktop bugs + bump to v1.5.0 build 9

### DIFF
--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -1146,7 +1146,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
@@ -1163,7 +1163,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1183,7 +1183,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
@@ -1200,7 +1200,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1250,11 +1250,11 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahLiveActivity/IqamahLiveActivity.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahLiveActivity/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.liveactivity;
 				PRODUCT_NAME = IqamahLiveActivity;
 				SDKROOT = iphoneos;
@@ -1268,11 +1268,11 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahLiveActivity/IqamahLiveActivity.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahLiveActivity/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.liveactivity;
 				PRODUCT_NAME = IqamahLiveActivity;
 				SDKROOT = iphoneos;
@@ -1285,7 +1285,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/InfoMac.plist;
@@ -1295,7 +1295,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fablesoft.iqamah.mac-widget";
 				PRODUCT_NAME = IqamahWidgetMac;
 				SDKROOT = macosx;
@@ -1310,7 +1310,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/InfoMac.plist;
@@ -1320,7 +1320,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fablesoft.iqamah.mac-widget";
 				PRODUCT_NAME = IqamahWidgetMac;
 				SDKROOT = macosx;
@@ -1373,7 +1373,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/Info.plist;
@@ -1383,7 +1383,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.widget;
 				PRODUCT_NAME = IqamahWidget;
 				SDKROOT = iphoneos;
@@ -1400,7 +1400,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/Info.plist;
@@ -1410,7 +1410,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.widget;
 				PRODUCT_NAME = IqamahWidget;
 				SDKROOT = iphoneos;
@@ -1490,7 +1490,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "iqamah/iOS/iqamah-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
@@ -1502,7 +1502,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1520,7 +1520,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "iqamah/iOS/iqamah-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
@@ -1532,7 +1532,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/iqamah/Views/HilalWatch/MoonPhaseView.swift
+++ b/iqamah/Views/HilalWatch/MoonPhaseView.swift
@@ -18,20 +18,24 @@ struct MoonPhaseView: View {
             let disc = Path(ellipseIn: rect)
             ctx.fill(disc, with: .color(.white.opacity(0.15)))
 
-            // Crescent via Path boolean subtraction (iOS 17+ / macOS 14+).
-            // No blend modes needed — geometrically correct on all display scales.
-            let illumination = abs(phase - 0.5) * 2 // 0 = full moon, 1 = new moon
-            let xOffset = (1.0 - illumination * 2) * r
-            let shadowRect = CGRect(x: cx - r + xOffset, y: cy - r, width: r * 2, height: r * 2)
-            let shadow = Path(ellipseIn: shadowRect)
-
-            let crescentPath: Path = if phase < 0.5 {
-                // Waxing — lit on right: disc minus shadow leaves right crescent
-                disc.subtracting(shadow)
+            // Crescent via Path.subtracting (iOS 17+ / macOS 14+).
+            //
+            // The shadow circle starts perfectly centered on the disc (new moon = 0 % lit)
+            // and moves sideways until it no longer overlaps (full moon = 100 % lit).
+            // disc.subtracting(shadow) = the lit portion inside the disc.
+            //
+            //   Waxing (phase 0 → 0.5): shadow moves LEFT → exposes right crescent
+            //   Waning (phase 0.5 → 1): shadow moves RIGHT → exposes left crescent
+            let shadowX: CGFloat = if phase < 0.5 {
+                -2 * r * CGFloat(2 * phase) // 0 at new → -2r at full
             } else {
-                // Waning — lit on left: shadow minus disc leaves left crescent
-                shadow.subtracting(disc)
+                2 * r * CGFloat(2 - 2 * phase) // +2r at full → 0 at new
             }
+
+            let shadowRect = CGRect(x: cx - r + shadowX, y: cy - r, width: r * 2, height: r * 2)
+            let shadow = Path(ellipseIn: shadowRect)
+            let crescentPath = disc.subtracting(shadow)
+
             ctx.fill(crescentPath, with: .color(.yellow.opacity(0.9)))
         }
         .frame(width: size, height: size)

--- a/iqamah/Views/LocationSetupView.swift
+++ b/iqamah/Views/LocationSetupView.swift
@@ -49,18 +49,29 @@ struct LocationSetupView: View {
                     }
                     .padding(.vertical, 4)
                 } else if showDetectedBadge {
+                    let locality = SettingsManager.shared.gpsLocality
+                    let coord = rawGPSCoordinate
                     HStack(spacing: 6) {
                         Image(systemName: "location.fill")
                             .font(.subheadline)
                             .foregroundColor(.accentColor)
-                        Text("Location detected")
-                            .font(.subheadline.weight(.medium))
-                            .foregroundColor(.accentColor)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(locality.isEmpty ? "Location detected" : "📍 \(locality)")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundColor(.accentColor)
+                            if let c = coord {
+                                Text(String(format: "%.4f°%@, %.4f°%@",
+                                            abs(c.latitude), c.latitude >= 0 ? "N" : "S",
+                                            abs(c.longitude), c.longitude >= 0 ? "E" : "W"))
+                                    .font(.caption2)
+                                    .foregroundColor(.accentColor.opacity(0.7))
+                            }
+                        }
                     }
                     .padding(.horizontal, 14)
-                    .padding(.vertical, 6)
+                    .padding(.vertical, 8)
                     .background(Color.accentColor.opacity(0.10))
-                    .clipShape(Capsule())
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     .transition(.scale(scale: 0.8).combined(with: .opacity))
                 } else if let error = locationService.locationError {
                     VStack(spacing: 8) {

--- a/iqamah/Views/PrayerTimesComponents.swift
+++ b/iqamah/Views/PrayerTimesComponents.swift
@@ -75,7 +75,17 @@ struct PrayerTimesTable: View {
                 #else
                     let isSunrise = prayer.name == "Sunrise"
                     if isSunrise {
-                        SunriseRow(time: adjusted, formatter: timeFormatter)
+                        SunriseRow(
+                            time: adjusted,
+                            formatter: timeFormatter,
+                            selectedAlert: Binding(
+                                get: { adhaanSelections["Sunrise"] ?? .silent },
+                                set: { alert in
+                                    adhaanSelections["Sunrise"] = alert
+                                    settingsManager.setAdhaan(alert, for: "Sunrise")
+                                }
+                            )
+                        )
                     } else {
                         PrayerTimeRow(
                             name: prayer.name,
@@ -171,32 +181,112 @@ struct PrayerTimesTable: View {
 
 // MARK: - Sunrise Row (US-0028)
 
-/// Muted info row for Sunrise — not a prayer, no adjustment controls.
+/// Sunrise row — shows time and an alert-tone picker (no adhaan, no adjustments).
 struct SunriseRow: View {
     let time: Date
     let formatter: DateFormatter
+    @Binding var selectedAlert: Adhaan
+
+    @State private var isPickerExpanded = false
+    @Environment(\.colorScheme) private var colorScheme
+    private var gold: Color { colorScheme == .dark ? .appGold : .appGoldDark }
 
     var body: some View {
-        HStack(spacing: 16) {
-            HStack(spacing: 14) {
-                Image(systemName: "sunrise.fill")
-                    .font(.body)
-                    .foregroundColor(.secondary) // AC-0063: no opacity reduction on semantic colour
-                    .frame(width: 44, height: 36)
-                Text("Sunrise")
-                    .font(.body)
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 16) {
+                HStack(spacing: 14) {
+                    Image(systemName: "sunrise.fill")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .frame(width: 44, height: 36)
+                    Text("Sunrise")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Text(formatter.string(from: time))
+                    .font(.title3.weight(.medium))
                     .foregroundColor(.secondary)
+                    .monospacedDigit()
+                    .frame(minWidth: 72, alignment: .trailing)
+
+                // Divider matching prayer rows
+                Rectangle()
+                    .fill(Color.primary.opacity(0.08))
+                    .frame(width: 1, height: 28)
+                    .padding(.horizontal, 10)
+
+                // Alert tone pill button
+                Button(action: { isPickerExpanded.toggle() }) {
+                    HStack(spacing: 3) {
+                        Text(selectedAlert.id == "silent" ? "No alert" : selectedAlert.shortName)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(selectedAlert.id == "silent"
+                                ? Color.orange.opacity(0.55)
+                                : Color.orange)
+                            .lineLimit(1)
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.horizontal, 8).padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .fill(Color.orange.opacity(selectedAlert.id == "silent" ? 0.07 : 0.12))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .strokeBorder(Color.orange.opacity(0.22), lineWidth: 0.5)
+                    )
+                }
+                .buttonStyle(.plain)
+                .frame(width: 100)
+                .accessibilityLabel(selectedAlert.id == "silent"
+                    ? "No alert for Sunrise. Tap to set."
+                    : "Alert for Sunrise: \(selectedAlert.displayName). Tap to change.")
+
+                // Mute placeholder (keeps alignment with prayer rows)
+                Color.clear.frame(width: 36)
             }
-            Spacer()
-            Text(formatter.string(from: time))
-                .font(.title3.weight(.medium))
-                .foregroundColor(.secondary)
-                .monospacedDigit()
-                .frame(minWidth: 100, alignment: .trailing)
-            Color.clear.frame(width: 76)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+
+            if isPickerExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Alert tone")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                        .tracking(0.4)
+                        .padding(.leading, 80)
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 6) {
+                            ForEach(Adhaan.availableForSunrise) { alert in
+                                let isSel = selectedAlert.id == alert.id
+                                Button(action: {
+                                    selectedAlert = alert
+                                    isPickerExpanded = false
+                                }) {
+                                    Text(alert.id == "silent" ? "No alert" : alert.shortName)
+                                        .font(.caption.weight(.medium))
+                                        .foregroundStyle(isSel ? .white : Color.orange)
+                                        .padding(.horizontal, 10).padding(.vertical, 5)
+                                        .background(Capsule().fill(isSel
+                                                ? Color.orange : Color.orange.opacity(0.08)))
+                                        .overlay(Capsule().strokeBorder(
+                                            Color.orange.opacity(isSel ? 0 : 0.25), lineWidth: 0.5
+                                        ))
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .padding(.leading, 80)
+                        .padding(.trailing, 20)
+                    }
+                }
+                .padding(.bottom, 8)
+            }
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 10)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Sunrise at \(formatter.string(from: time))")
     }

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -150,7 +150,7 @@ struct PrayerTimesView: View {
         VStack(spacing: 0) {
             // ── Primary header: brand + location + mute only ─────────
             HStack(spacing: 12) {
-                Image("AppIcon")
+                Image(nsImage: NSApplication.shared.applicationIconImage)
                     .resizable()
                     .frame(width: 64, height: 64)
                     .shadow(color: Color.primary.opacity(0.10), radius: 3, x: 0, y: 1)
@@ -248,11 +248,12 @@ struct PrayerTimesView: View {
 
                 Spacer()
 
-                Button("Details") {
+                Button("Hilal Watch ›") {
                     openHilalWatch()
                 }
                 .buttonStyle(.borderless)
-                .font(.caption)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(Color.appGold)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)


### PR DESCRIPTION
## Summary

Five desktop fixes plus version bump for next App Store submission.

### Moon crescent malformed
The waning crescent formula used `shadow.subtracting(disc)`, which returns the area of the shadow ellipse *outside* the disc — rendering a gold sliver to the **left of** the dark circle rather than inside it. Fixed with a correct two-circle formula: `disc.subtracting(shadow)` for both waxing and waning, with the shadow starting centered (new moon = 0 % lit) and moving sideways (full moon = 100 % lit).

### App icon missing in macOS header
`Image("AppIcon")` looks for an Image Set in the asset catalog, but the macOS bundle only has an App Icon Set — so it logs "No image named AppIcon found" and shows nothing. Fixed to use `Image(nsImage: NSApplication.shared.applicationIconImage)` which reads directly from the bundle.

### "Details" button → "Hilal Watch ›"
The button opens the Hilal Watch window but was labelled "Details" — renamed and styled with gold tint to match the button in the iOS hero card.

### Sunrise alert picker (macOS)
`SunriseRow` now has an amber alert-tone pill and inline picker using `Adhaan.availableForSunrise`. No adhaan recordings, no mute chip.

### Location wizard badge
Shows `📍 [locality name]` + lat/lon coordinates after GPS detection instead of the generic "Location detected" text.

### Version
All targets → **1.5.0 build 9** (1.4.0 build 8 is live on the App Store).

## Test Plan
- [ ] macOS: moon crescent renders as gold sliver inside dark disc (not outside)
- [ ] macOS: app icon appears in header row
- [ ] macOS: moon/Hilal Watch row shows "Hilal Watch ›" button; clicking opens Hilal Watch window
- [ ] macOS: right-click status menu → Moon Sighting… opens Hilal Watch window
- [ ] macOS: Sunrise row has amber "No alert" pill; clicking expands alert tone picker
- [ ] All platforms: location wizard shows locality name + coordinates after GPS detection
- [ ] All targets: version 1.5.0 build 9

Generated with Claude Code