### PR TITLE
fix: guard NSApplication icon with #if os(macOS)

### DIFF
--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -150,10 +150,12 @@ struct PrayerTimesView: View {
         VStack(spacing: 0) {
             // ── Primary header: brand + location + mute only ─────────
             HStack(spacing: 12) {
+                #if os(macOS)
                 Image(nsImage: NSApplication.shared.applicationIconImage)
                     .resizable()
                     .frame(width: 64, height: 64)
                     .shadow(color: Color.primary.opacity(0.10), radius: 3, x: 0, y: 1)
+                #endif
 
                 Text("Iqamah")
                     .font(.system(size: titleFontSize, weight: .bold, design: .serif))

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -151,10 +151,10 @@ struct PrayerTimesView: View {
             // ── Primary header: brand + location + mute only ─────────
             HStack(spacing: 12) {
                 #if os(macOS)
-                Image(nsImage: NSApplication.shared.applicationIconImage)
-                    .resizable()
-                    .frame(width: 64, height: 64)
-                    .shadow(color: Color.primary.opacity(0.10), radius: 3, x: 0, y: 1)
+                    Image(nsImage: NSApplication.shared.applicationIconImage)
+                        .resizable()
+                        .frame(width: 64, height: 64)
+                        .shadow(color: Color.primary.opacity(0.10), radius: 3, x: 0, y: 1)
                 #endif
 
                 Text("Iqamah")


### PR DESCRIPTION
NSApplication is macOS-only but macOSBody compiles on all targets. Wraps the Image(nsImage:) call in #if os(macOS) so iOS builds succeed.