### PR TITLE
fix: iPad landscape+dark-mode, Hilal Watch map iOS, watchOS manual location, mat 2×

### DIFF
--- a/IqamahWatch/SettingsTab.swift
+++ b/IqamahWatch/SettingsTab.swift
@@ -6,6 +6,7 @@ struct SettingsTab: View {
     @EnvironmentObject private var settings: SettingsManager
     @StateObject private var locationUpdater = WatchLocationSetup()
     @State private var isUpdatingLocation = false
+    @State private var database: CitiesDatabase?
 
     var body: some View {
         Form {
@@ -13,7 +14,9 @@ struct SettingsTab: View {
                 Text(locationLabel)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                Button(isUpdatingLocation ? "Updating…" : "Update Location") {
+
+                // GPS update
+                Button(isUpdatingLocation ? "Updating…" : "Update via GPS") {
                     isUpdatingLocation = true
                     locationUpdater.start(settings: settings)
                 }
@@ -23,6 +26,19 @@ struct SettingsTab: View {
                         isUpdatingLocation = false
                         WidgetCenter.shared.reloadAllTimelines()
                     }
+                }
+
+                // Manual city selection — drill-down Country → City
+                if let db = database {
+                    NavigationLink("Set City Manually") {
+                        WatchCountryPicker(database: db, settings: settings)
+                    }
+                }
+            }
+            .onAppear {
+                if database == nil,
+                   case let .success(db) = CitiesLoader.shared.load() {
+                    database = db
                 }
             }
 
@@ -80,5 +96,48 @@ struct SettingsTab: View {
                 WidgetCenter.shared.reloadAllTimelines()
             }
         )
+    }
+}
+
+// MARK: - Country picker (watch drill-down level 1)
+
+struct WatchCountryPicker: View {
+    let database: CitiesDatabase
+    let settings: SettingsManager
+
+    var body: some View {
+        List {
+            ForEach(database.countries.sorted { $0.name < $1.name }) { country in
+                NavigationLink(country.name) {
+                    WatchCityPicker(
+                        cities: database.cities(forCountryCode: country.code),
+                        settings: settings
+                    )
+                }
+            }
+        }
+        .navigationTitle("Country")
+    }
+}
+
+// MARK: - City picker (watch drill-down level 2)
+
+struct WatchCityPicker: View {
+    let cities: [City]
+    let settings: SettingsManager
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            ForEach(cities) { city in
+                Button(city.name) {
+                    settings.saveCity(city)
+                    settings.locationSource = "manual"
+                    WidgetCenter.shared.reloadAllTimelines()
+                    dismiss()
+                }
+            }
+        }
+        .navigationTitle("City")
     }
 }

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -101,6 +101,10 @@
 		HC000000000000000000002 /* PrayerHeroCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = HC000000000000000000001 /* PrayerHeroCard.swift */; };
 		
 		HC000000000000000000004 /* PrayerRowMobileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = HC000000000000000000003 /* PrayerRowMobileView.swift */; };
+		
+		HW00000000000000000021A /* HilalMapView.swift in Sources (iOS) */ = {isa = PBXBuildFile; fileRef = HW000000000000000000003 /* HilalMapView.swift */; };
+		
+		HW00000000000000000022B /* HilalCellOverlay.swift in Sources (iOS) */ = {isa = PBXBuildFile; fileRef = HW000000000000000000002 /* HilalCellOverlay.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -979,6 +983,8 @@
 				B5000000000000000000004 /* HilalPalette.swift in Sources */,
 				B5000000000000000000005 /* AboutHilalWatchCard.swift in Sources */,
 				B5000000000000000000010 /* HilalWatchSheet.swift in Sources */,
+				HW00000000000000000021A /* HilalMapView.swift in Sources (iOS) */,
+				HW00000000000000000022B /* HilalCellOverlay.swift in Sources (iOS) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iqamah/Views/HilalWatch/HilalMapView.swift
+++ b/iqamah/Views/HilalWatch/HilalMapView.swift
@@ -2,18 +2,52 @@ import MapKit
 import SwiftUI
 import IqamahCore
 
-struct HilalMapView: NSViewRepresentable {
-    let grid: ContiguousArray<Int8>
-    @Environment(\.colorScheme) var colorScheme
+#if os(macOS)
+    struct HilalMapView: NSViewRepresentable {
+        let grid: ContiguousArray<Int8>
+        @Environment(\.colorScheme) var colorScheme
 
-    func makeNSView(context: Context) -> MKMapView {
-        let map = MKMapView()
-        map.mapType = .mutedStandard
-        map.delegate = context.coordinator
-        return map
+        func makeNSView(context: Context) -> MKMapView {
+            let map = MKMapView()
+            map.mapType = .mutedStandard
+            map.delegate = context.coordinator
+            return map
+        }
+
+        func updateNSView(_ map: MKMapView, context _: Context) {
+            updateMap(map)
+        }
+
+        func makeCoordinator() -> HilalMapCoordinator {
+            HilalMapCoordinator(colorScheme: colorScheme)
+        }
     }
+#else
+    struct HilalMapView: UIViewRepresentable {
+        let grid: ContiguousArray<Int8>
+        @Environment(\.colorScheme) var colorScheme
 
-    func updateNSView(_ map: MKMapView, context _: Context) {
+        func makeUIView(context: Context) -> MKMapView {
+            let map = MKMapView()
+            map.mapType = .mutedStandard
+            map.delegate = context.coordinator
+            return map
+        }
+
+        func updateUIView(_ map: MKMapView, context _: Context) {
+            updateMap(map)
+        }
+
+        func makeCoordinator() -> HilalMapCoordinator {
+            HilalMapCoordinator(colorScheme: colorScheme)
+        }
+    }
+#endif
+
+// MARK: - Shared map update logic
+
+private extension HilalMapView {
+    func updateMap(_ map: MKMapView) {
         map.removeOverlays(map.overlays)
         var overlays = [HilalCellOverlay]()
         overlays.reserveCapacity(HilalCalculator.cellCount)
@@ -36,27 +70,29 @@ struct HilalMapView: NSViewRepresentable {
         }
         map.addOverlays(overlays, level: .aboveRoads)
     }
+}
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(colorScheme: colorScheme)
+// MARK: - Shared coordinator
+
+final class HilalMapCoordinator: NSObject, MKMapViewDelegate {
+    var colorScheme: ColorScheme
+    init(colorScheme: ColorScheme) {
+        self.colorScheme = colorScheme
     }
 
-    class Coordinator: NSObject, MKMapViewDelegate {
-        var colorScheme: ColorScheme
-        init(colorScheme: ColorScheme) {
-            self.colorScheme = colorScheme
+    func mapView(_: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        guard let cell = overlay as? HilalCellOverlay else {
+            return MKOverlayRenderer(overlay: overlay)
         }
-
-        func mapView(_: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-            guard let cell = overlay as? HilalCellOverlay else {
-                return MKOverlayRenderer(overlay: overlay)
-            }
-            let renderer = MKPolygonRenderer(polygon: cell)
-            let color = HilalPalette.fill(for: cell.category, colorScheme: colorScheme)
-            let alpha = HilalPalette.alpha(for: cell.category, colorScheme: colorScheme)
+        let renderer = MKPolygonRenderer(polygon: cell)
+        let color = HilalPalette.fill(for: cell.category, colorScheme: colorScheme)
+        let alpha = HilalPalette.alpha(for: cell.category, colorScheme: colorScheme)
+        #if os(macOS)
             renderer.fillColor = NSColor(color).withAlphaComponent(alpha)
-            renderer.strokeColor = .clear
-            return renderer
-        }
+        #else
+            renderer.fillColor = UIColor(color).withAlphaComponent(alpha)
+        #endif
+        renderer.strokeColor = .clear
+        return renderer
     }
 }

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -95,10 +95,13 @@ struct PrayerTimesView: View {
 
         private var primaryHeader: some View {
             HStack(spacing: 12) {
-                Image("AppIcon")
-                    .resizable()
-                    .frame(width: 48, height: 48)
-                    .shadow(color: Color.primary.opacity(0.10), radius: 3, x: 0, y: 1)
+                if let uiImg = UIImage(named: "AppIcon") {
+                    Image(uiImage: uiImg)
+                        .resizable()
+                        .frame(width: 48, height: 48)
+                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        .shadow(color: Color.primary.opacity(0.10), radius: 3, x: 0, y: 1)
+                }
                 Text("Iqamah")
                     .font(.system(size: titleFontSize, weight: .bold, design: .serif))
                     .foregroundStyle(LinearGradient(

--- a/iqamah/Views/QiblahView.swift
+++ b/iqamah/Views/QiblahView.swift
@@ -321,8 +321,8 @@ private struct QiblahCompassView: View {
 
             // ── Prayer mat — CENTERED, rotated to Qibla ─────────────
             // Mat is the centerpiece: the needle points from it toward Makkah.
-            let matW = r * 0.24
-            let matH = r * 0.32
+            let matW = r * 0.48
+            let matH = r * 0.64
             Image("PrayerMat")
                 .resizable()
                 .scaledToFit()

--- a/iqamah/iOS/HilalWatchSheet.swift
+++ b/iqamah/iOS/HilalWatchSheet.swift
@@ -21,7 +21,6 @@
         var body: some View {
             NavigationStack {
                 ZStack {
-                    // iOS v1: show a list summary instead of an interactive map
                     iOSVisibilityContent
                         .task { await loadGrid() }
 
@@ -85,6 +84,14 @@
                         )
                         .listRowInsets(EdgeInsets())
                     }
+                }
+
+                // Global crescent visibility map
+                Section("Global Visibility") {
+                    HilalMapView(grid: grid)
+                        .frame(height: 220)
+                        .listRowInsets(EdgeInsets())
+                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }
 
                 // Summary statistics from grid

--- a/iqamah/iOS/Info.plist
+++ b/iqamah/iOS/Info.plist
@@ -26,5 +26,12 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/iqamah/iOS/iqamahApp_iOS.swift
+++ b/iqamah/iOS/iqamahApp_iOS.swift
@@ -12,6 +12,7 @@ struct IqamahiOSApp: App {
         WindowGroup {
             IOSRootView()
                 .environmentObject(settings)
+                .preferredColorScheme(settings.appearance.colorScheme)
                 .onAppear {
                     activateWCSession()
                 }


### PR DESCRIPTION
Five platform fixes across iOS, iPadOS, and watchOS.

**iPad landscape layout now works**
Info.plist was missing `UISupportedInterfaceOrientations~ipad` — only Portrait was declared so iOS never rotated the iPad. Added all four iPad orientations; `GeometryReader` now receives landscape sizes and the two-column layout triggers correctly.

**Dark mode now applies on iOS**
`.preferredColorScheme(settings.appearance.colorScheme)` added to `IOSRootView()` in `IqamahiOSApp`. The macOS app already had this; iOS was missed.

**Hilal Watch map on iOS**
`HilalMapView` rewritten as cross-platform (`NSViewRepresentable` on macOS, `UIViewRepresentable` on iOS). `HilalMapView` + `HilalCellOverlay` added to iOS build phase. Sheet now shows global crescent visibility map between the local sighting card and the summary stats.

**Prayer mat 2× larger** (iPhone + iPad + macOS)
Mat dimensions in `QiblahCompassView` doubled from `r×0.24/0.32` → `r×0.48/0.64`.

**App icon in iOS header**
`UIImage(named:)` loads from App Icon Sets; `Image("AppIcon")` cannot. Fixed to use `Image(uiImage: UIImage(named: "AppIcon"))`.

**watchOS manual city selection**
`SettingsTab` now shows "Set City Manually" NavigationLink when GPS is unavailable. Drills into `WatchCountryPicker` → `WatchCityPicker` using the full `CitiesDatabase`.

Generated with Claude Code