### PR TITLE
fix: Hilal Watch performance + full-screen + Qibla needle

### DIFF
--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		HW00000000000000000021A /* HilalMapView.swift in Sources (iOS) */ = {isa = PBXBuildFile; fileRef = HW000000000000000000003 /* HilalMapView.swift */; };
 		
 		HW00000000000000000022B /* HilalCellOverlay.swift in Sources (iOS) */ = {isa = PBXBuildFile; fileRef = HW000000000000000000002 /* HilalCellOverlay.swift */; };
+		
+		HL000000000000000000002 /* HilalWatchPreloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = HL000000000000000000001 /* HilalWatchPreloader.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -276,6 +278,8 @@
 		HC000000000000000000001 /* PrayerHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerHeroCard.swift; sourceTree = "<group>"; };
 		
 		HC000000000000000000003 /* PrayerRowMobileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerRowMobileView.swift; sourceTree = "<group>"; };
+		
+		HL000000000000000000001 /* HilalWatchPreloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HilalWatchPreloader.swift; sourceTree = "<group>"; };
 		/* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -555,6 +559,7 @@
 				AM000000000000000000001R /* PrayerActivityManager.swift */,
 				AM000000000000000000002R /* PrayerActivityAttributes.swift */,
 				HC000000000000000000001 /* PrayerHeroCard.swift */,
+				HL000000000000000000001 /* HilalWatchPreloader.swift */,
 				HC000000000000000000003 /* PrayerRowMobileView.swift */,
 				iOS0000000000000000000013 /* Info.plist */,
 				iOS0000000000000000000014 /* iqamah-iOS.entitlements */,
@@ -983,6 +988,7 @@
 				B5000000000000000000004 /* HilalPalette.swift in Sources */,
 				B5000000000000000000005 /* AboutHilalWatchCard.swift in Sources */,
 				B5000000000000000000010 /* HilalWatchSheet.swift in Sources */,
+				HL000000000000000000002 /* HilalWatchPreloader.swift in Sources */,
 				HW00000000000000000021A /* HilalMapView.swift in Sources (iOS) */,
 				HW00000000000000000022B /* HilalCellOverlay.swift in Sources (iOS) */,
 			);

--- a/iqamah/Views/HilalWatch/HilalMapView.swift
+++ b/iqamah/Views/HilalWatch/HilalMapView.swift
@@ -47,24 +47,40 @@ import IqamahCore
 // MARK: - Shared map update logic
 
 private extension HilalMapView {
+    /// Display step in bands: 2 = 4°×4° display cells (4,050 polygons vs 16,200).
+    /// The data grid stays full-resolution; we just merge 2×2 blocks for rendering
+    /// to stay well under MapKit's 50,000 Metal buffer threshold.
+    static let displayStep = 2
+
     func updateMap(_ map: MKMapView) {
         map.removeOverlays(map.overlays)
+        let step = Self.displayStep
         var overlays = [HilalCellOverlay]()
-        overlays.reserveCapacity(HilalCalculator.cellCount)
-        for latBand in 0 ..< HilalCalculator.latitudeBands {
+        overlays.reserveCapacity(HilalCalculator.cellCount / (step * step))
+        for latBand in stride(from: 0, to: HilalCalculator.latitudeBands, by: step) {
             let lat = Double(latBand) * 2.0 - 88.0
-            for lonBand in 0 ..< HilalCalculator.longitudeBands {
+            for lonBand in stride(from: 0, to: HilalCalculator.longitudeBands, by: step) {
                 let lon = Double(lonBand) * 2.0 - 178.0
-                let idx = latBand * HilalCalculator.longitudeBands + lonBand
-                let rawCategory = grid[idx]
+                // Merge step×step cells: take the most-favourable category
+                var best = Int8(VisibilityCategory.D.rawValue)
+                for dl in 0 ..< step {
+                    for dm in 0 ..< step {
+                        let r = latBand + dl, c = lonBand + dm
+                        guard r < HilalCalculator.latitudeBands,
+                              c < HilalCalculator.longitudeBands else { continue }
+                        let v = grid[r * HilalCalculator.longitudeBands + c]
+                        if v > best { best = v }
+                    }
+                }
+                let size = Double(step) * 2.0
                 var coords = [
                     CLLocationCoordinate2D(latitude: lat, longitude: lon),
-                    CLLocationCoordinate2D(latitude: lat, longitude: lon + 2.0),
-                    CLLocationCoordinate2D(latitude: lat + 2.0, longitude: lon + 2.0),
-                    CLLocationCoordinate2D(latitude: lat + 2.0, longitude: lon),
+                    CLLocationCoordinate2D(latitude: lat, longitude: lon + size),
+                    CLLocationCoordinate2D(latitude: lat + size, longitude: lon + size),
+                    CLLocationCoordinate2D(latitude: lat + size, longitude: lon),
                 ]
                 let overlay = HilalCellOverlay(coordinates: &coords, count: 4)
-                overlay.category = VisibilityCategory(rawValue: Int(rawCategory)) ?? .D
+                overlay.category = VisibilityCategory(rawValue: Int(best)) ?? .D
                 overlays.append(overlay)
             }
         }

--- a/iqamah/Views/QiblahView.swift
+++ b/iqamah/Views/QiblahView.swift
@@ -298,8 +298,8 @@ private struct QiblahCompassView: View {
                 var path = Path()
                 path.move(to: CGPoint(x: cx, y: cy))
                 path.addLine(to: CGPoint(x: x2, y: y2))
-                ctx.stroke(path, with: .color(Color.appGold.opacity(0.80)),
-                           style: StrokeStyle(lineWidth: 2, dash: [6, 4], dashPhase: 0))
+                ctx.stroke(path, with: .color(Color.appGold.opacity(0.50)),
+                           style: StrokeStyle(lineWidth: 3.5, dash: [8, 5], dashPhase: 0))
                 // Arrowhead
                 let backLen: Double = Double(r) * 0.065
                 let perpAngle = rad + .pi / 2

--- a/iqamah/iOS/HilalWatchPreloader.swift
+++ b/iqamah/iOS/HilalWatchPreloader.swift
@@ -1,0 +1,68 @@
+#if os(iOS)
+    import IqamahCore
+    import Foundation
+
+    /// Computes the Hilal grid in the background when the app becomes active,
+    /// so HilalWatchSheet shows results instantly without a loading delay.
+    @MainActor
+    final class HilalWatchPreloader: ObservableObject {
+        static let shared = HilalWatchPreloader()
+
+        @Published private(set) var grid: ContiguousArray<Int8> =
+            ContiguousArray(repeating: 1, count: HilalCalculator.cellCount)
+        @Published private(set) var localCard: LocalSightingValues?
+        @Published private(set) var isReady = false
+        @Published private(set) var newMoonDate: Date = Date()
+
+        // Evening and criterion for which the cached grid was computed
+        private var cachedEvening: Evening?
+        private var cachedCriterion: String?
+
+        private var activeTask: Task<Void, Never>?
+
+        /// Call from app-active / app-appear to start background computation.
+        func prefetch(settings: SettingsManager,
+                      evening: Evening = .d29,
+                      criterionChoice: HilalCriterionPicker.CriterionChoice = .odeh) {
+            let criterion = criterionChoice.criterion
+            let criterionID = criterionChoice.id
+
+            // Skip if already cached for same params
+            if cachedEvening == evening, cachedCriterion == criterionID, isReady { return }
+
+            activeTask?.cancel()
+            isReady = false
+
+            activeTask = Task(priority: .background) { [weak self] in
+                guard let self else { return }
+                let prev = NewMoon.previous(before: Date())
+                let req = HilalGridRequest(
+                    newMoonJD: prev.julianDay,
+                    evening: evening,
+                    criterion: criterion
+                )
+                let computed = await HilalCalculator.shared.computeGrid(req)
+                guard !Task.isCancelled else { return }
+
+                var card: LocalSightingValues?
+                if let coord = settings.activeCoordinate {
+                    let offset = evening == .d29 ? 1.0 : 2.0
+                    let date = Date.fromJulianDay(prev.julianDay + offset)
+                    card = HilalCalculator.shared.computeLocalCard(
+                        date: date,
+                        latitude: coord.latitude,
+                        longitude: coord.longitude,
+                        criterion: criterion
+                    )
+                }
+
+                grid = computed
+                localCard = card
+                newMoonDate = prev
+                cachedEvening = evening
+                cachedCriterion = criterionID
+                isReady = true
+            }
+        }
+    }
+#endif

--- a/iqamah/iOS/HilalWatchSheet.swift
+++ b/iqamah/iOS/HilalWatchSheet.swift
@@ -8,6 +8,7 @@
     struct HilalWatchSheet: View {
         @EnvironmentObject private var settings: SettingsManager
         @Environment(\.dismiss) private var dismiss
+        @ObservedObject private var preloader = HilalWatchPreloader.shared
         @State private var selectedEvening: Evening = .d29
         @State private var selectedCriterion: HilalCriterionPicker.CriterionChoice = .odeh
         @State private var grid: ContiguousArray<Int8> = ContiguousArray(
@@ -22,7 +23,16 @@
             NavigationStack {
                 ZStack {
                     iOSVisibilityContent
-                        .task { await loadGrid() }
+                        .task {
+                            // Use pre-computed data if available; otherwise compute now
+                            if preloader.isReady {
+                                grid = preloader.grid
+                                localCard = preloader.localCard
+                                newMoonDate = preloader.newMoonDate
+                            } else {
+                                await loadGrid()
+                            }
+                        }
 
                     if isLoading {
                         ProgressView("Computing\u{2026}")

--- a/iqamah/iOS/iOSRootView.swift
+++ b/iqamah/iOS/iOSRootView.swift
@@ -13,7 +13,7 @@ struct IOSRootView: View {
                 .onReceive(NotificationCenter.default.publisher(for: .openPrayerTimesTab)) { _ in
                     selectedTab = 0
                 }
-                .sheet(isPresented: $showHilalWatch) {
+                .fullScreenCover(isPresented: $showHilalWatch) {
                     HilalWatchSheet()
                         .environmentObject(settings)
                 }

--- a/iqamah/iOS/iqamahApp_iOS.swift
+++ b/iqamah/iOS/iqamahApp_iOS.swift
@@ -25,6 +25,8 @@ struct IqamahiOSApp: App {
                 .onChange(of: scenePhase) { _, phase in
                     if phase == .active {
                         reschedule()
+                        // Pre-compute Hilal grid in background so sheet opens instantly
+                        HilalWatchPreloader.shared.prefetch(settings: settings)
                         if settings.liveActivityEnabled {
                             Task { await PrayerActivityManager.shared.startOrUpdateActivity(settings: settings) }
                         }


### PR DESCRIPTION
Performance, UX, and visual fixes for Hilal Watch and Qibla.

**Hilal Watch: instant opening**
New `HilalWatchPreloader` singleton starts computing the grid in the background (`Task(priority: .background)`) when the app enters the `.active` scene phase. Sheet reads from cache if ready — no more 30+ second wait.

**Hilal Watch: fixed Metal buffer overflow**
16,200 polygon overlays created 51,642 Metal GPU resources, exceeding the 50,000 threshold. Symptoms in the debug log: 'Exceeded Metal Buffer threshold', 71-second gesture gate timeout, and eventual map reset. Fix: render the map with 4°×4° display cells (merging 2×2 blocks → 4,050 polygons → ~13,000 Metal resources). Grid data accuracy unchanged; only the visual resolution changes.

**Hilal Watch: full-screen**
Changed `.sheet` → `.fullScreenCover` so the map and data occupy the entire display.

**Qibla needle**
Heavier (3.5pt vs 2pt), longer dashes, lighter opacity (50% vs 80%).

Generated with Claude Code