### PR TITLE
fix: dismantleNSView/UIView in HilalMapView — prevent Metal texture lifetime assertion

### DIFF
--- a/iqamah/Views/HilalWatch/HilalMapView.swift
+++ b/iqamah/Views/HilalWatch/HilalMapView.swift
@@ -21,6 +21,14 @@ import IqamahCore
         func makeCoordinator() -> HilalMapCoordinator {
             HilalMapCoordinator(colorScheme: colorScheme)
         }
+
+        /// Remove all overlays and nil the delegate before the view leaves the hierarchy.
+        /// Prevents the MTLDebugDevice "Metal object destroyed while required by command buffer"
+        /// assertion that fires when MapKit's GPU render is still in flight at window close.
+        static func dismantleNSView(_ nsView: MKMapView, coordinator _: HilalMapCoordinator) {
+            nsView.removeOverlays(nsView.overlays)
+            nsView.delegate = nil
+        }
     }
 #else
     struct HilalMapView: UIViewRepresentable {
@@ -40,6 +48,13 @@ import IqamahCore
 
         func makeCoordinator() -> HilalMapCoordinator {
             HilalMapCoordinator(colorScheme: colorScheme)
+        }
+
+        /// Same teardown as macOS — clears overlays and breaks the delegate reference
+        /// before SwiftUI removes the UIView, avoiding Metal command buffer lifecycle errors.
+        static func dismantleUIView(_ uiView: MKMapView, coordinator _: HilalMapCoordinator) {
+            uiView.removeOverlays(uiView.overlays)
+            uiView.delegate = nil
         }
     }
 #endif


### PR DESCRIPTION
Adds dismantleNSView (macOS) and dismantleUIView (iOS) to HilalMapView. SwiftUI calls these static methods synchronously before removing the bridged native view. Removing all polygon overlays and nilling the delegate at this point allows MapKit's GPU command buffers to drain before the CAMetalLayer drawable is released, eliminating the MTLDebugDevice 'Metal object destroyed while required by command buffer' assertion seen when closing the Hilal Watch window.