### PR TITLE
fix: status bar window routing — correct main window, Hilal Watch foreground

### DIFF
--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -314,24 +314,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         statusItem?.menu = nil
     }
 
+    /// The Hilal Watch window title — used to exclude it when searching for the main window.
+    private static let hilalWatchWindowTitle = "Hilal Watch"
+
+    /// Returns the prayer-times main window, explicitly excluding the Hilal Watch window.
+    /// Falls back to searching all windows so we never confuse the two.
+    private var resolvedMainWindow: NSWindow? {
+        // 1. Use the cached reference if it's still the right window.
+        if let w = mainWindow, w.title != Self.hilalWatchWindowTitle { return w }
+        // 2. Search for the first non-Hilal-Watch, non-panel window.
+        let candidate = NSApplication.shared.windows.first {
+            !($0 is NSPanel) && $0.title != Self.hilalWatchWindowTitle
+        }
+        if let w = candidate {
+            mainWindow = w
+            w.delegate = self
+        }
+        return candidate
+    }
+
     @objc func showWindow() {
         // Switch to .regular so the app appears in Cmd+Tab while the window is open.
         // The Dock icon temporarily appears — this is expected macOS behaviour for
         // hybrid menu-bar/window apps (same pattern used by Bartender, Fantastical, etc.).
         NSApplication.shared.setActivationPolicy(.regular)
-
-        if let window = mainWindow {
-            window.makeKeyAndOrderFront(nil)
-        } else if let window = NSApplication.shared.windows.first {
-            mainWindow = window
-            window.delegate = self
-            window.makeKeyAndOrderFront(nil)
-        }
+        resolvedMainWindow?.makeKeyAndOrderFront(nil)
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
     @objc func toggleWindow() {
-        if let window = mainWindow {
+        if let window = resolvedMainWindow {
             if window.isVisible {
                 hideWindow(window)
             } else {
@@ -350,6 +362,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func openHilalWatch() {
         NotificationCenter.default.post(name: .openHilalWatch, object: nil)
+        // openWindow(id:) is async — activate after a brief run-loop turn so the
+        // Hilal Watch window has been created and is ready to receive focus.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+        }
     }
 
     @objc func openSupport() {


### PR DESCRIPTION
Three related menu bar bugs all caused by the same root issue.

**Root cause**: `showWindow()` fell back to `NSApplication.shared.windows.first` when `mainWindow` was nil. After Hilal Watch had been opened, `windows.first` returned the Hilal Watch window — and the fallback then *overwrote* `mainWindow` with it. Every subsequent 'Open Main Window' call (and the left-click) showed Hilal Watch.

**Fixes:**
- Added `resolvedMainWindow` computed property that explicitly excludes `NSWindow`s titled 'Hilal Watch' when searching for the main window. Used in `showWindow()` and `toggleWindow()`.
- `openHilalWatch()` now calls `NSApplication.shared.activate(ignoringOtherApps: true)` after a 0.15 s delay (to let SwiftUI's async `openWindow(id:)` complete) so Hilal Watch comes to the foreground.

Generated with Claude Code