### PR TITLE
fix: watchOS 10+ icon format + reliable city database loading

### DIFF
--- a/IqamahWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/IqamahWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,11 +1,14 @@
 {
   "images": [
-    { "filename": "icon_44x44@2x.png",   "idiom": "watch",          "scale": "2x", "size": "44x44" },
-    { "filename": "icon_50x50@2x.png",   "idiom": "watch",          "scale": "2x", "size": "50x50" },
-    { "filename": "icon_86x86@2x.png",   "idiom": "watch",          "scale": "2x", "size": "86x86" },
-    { "filename": "icon_98x98@2x.png",   "idiom": "watch",          "scale": "2x", "size": "98x98" },
-    { "filename": "icon_108x108@2x.png", "idiom": "watch",          "scale": "2x", "size": "108x108" },
-    { "filename": "icon_1024x1024.png",  "idiom": "watch-marketing","scale": "1x", "size": "1024x1024" }
+    {
+      "filename": "icon_1024x1024.png",
+      "idiom": "universal",
+      "platform": "watchos",
+      "size": "1024x1024"
+    }
   ],
-  "info": { "author": "xcode", "version": 1 }
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
 }

--- a/IqamahWatch/SettingsTab.swift
+++ b/IqamahWatch/SettingsTab.swift
@@ -29,16 +29,16 @@ struct SettingsTab: View {
                 }
 
                 // Manual city selection — drill-down Country → City
+                // Uses .task on the Form (not .onAppear on the Section) for reliable
+                // loading on watchOS where Section.onAppear can silently not fire.
                 if let db = database {
                     NavigationLink("Set City Manually") {
                         WatchCountryPicker(database: db, settings: settings)
                     }
-                }
-            }
-            .onAppear {
-                if database == nil,
-                   case let .success(db) = CitiesLoader.shared.load() {
-                    database = db
+                } else {
+                    Text("Loading cities…")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
                 }
             }
 
@@ -76,6 +76,13 @@ struct SettingsTab: View {
 
             Section("Display") {
                 Toggle("24-hour time", isOn: $settings.use24HourTime)
+            }
+        }
+        .task {
+            // .task on the Form fires reliably on watchOS; Section.onAppear can be missed.
+            guard database == nil else { return }
+            if case let .success(db) = CitiesLoader.shared.load() {
+                database = db
             }
         }
     }


### PR DESCRIPTION
Two watchOS fixes.

**watchOS icon (grey circle → app icon)**
The AppIcon appiconset was using the watchOS 7-9 format with multiple idiom:watch entries. watchOS 10+ requires a single 1024×1024 icon with idiom:universal + platform:watchos. The old format renders as the generic grey placeholder on any watchOS 10 or newer device/simulator.

**Set City Manually always disabled**
onAppear on a Section nested inside a Form is not reliably called on watchOS — the view may be 'appeared' before the Section is visible, or the callback is silently skipped. Moved database loading to .task on the Form (parent level), which fires dependably. Added a 'Loading cities…' tertiary label as a placeholder while the database loads.