### PR TITLE
fix: add @main to PrayerLiveActivityView — iOS 26 extension entry point

### DIFF
--- a/IqamahLiveActivity/PrayerLiveActivityView.swift
+++ b/IqamahLiveActivity/PrayerLiveActivityView.swift
@@ -42,6 +42,10 @@ private struct CrescentView: View {
 
 // MARK: - Widget entry point
 
+/// `@main` designates this as the extension's binary entry point.
+/// Without it the OS cannot locate the widget on iOS 16.2+ and will
+/// immediately terminate the extension (and the host app) at load time.
+@main
 @available(iOS 16.2, *)
 struct PrayerLiveActivityView: Widget {
     var body: some WidgetConfiguration {


### PR DESCRIPTION
The IqamahLiveActivity extension had no @main attribute, leaving the binary with no designated entry point. iOS 16-18 tolerated this via Objective-C reflection to find the single Widget type, but iOS 26 enforces @main strictly — the extension is killed at load time, which kills the host app before Xcode can attach. This manifested as 'Application launch did not return a process handle' / 'No such process' on iOS 26 simulators.