### PR TITLE
fix: HilalWatch share, adhaan preview+stop, compass visual improvements

### DIFF
--- a/iqamah/Views/QiblahView.swift
+++ b/iqamah/Views/QiblahView.swift
@@ -92,7 +92,7 @@ struct QiblahView: View {
                     .padding(.top, 16)
                     .accessibilityAddTraits(.isHeader)
                 Text(String(format: "%.1f° %@", qiblahBearing, cardinalDirection))
-                    .font(.subheadline.weight(.medium))
+                    .font(.title3.weight(.semibold))
                     .foregroundColor(.secondary)
                 if !cityName.isEmpty {
                     Text("from \(cityName)")
@@ -172,7 +172,7 @@ struct QiblahView: View {
                     .padding(.top, 20)
                     .accessibilityAddTraits(.isHeader)
                 Text(String(format: "%.1f° %@", qiblahBearing, cardinalDirection))
-                    .font(.subheadline.weight(.medium))
+                    .font(.title3.weight(.semibold))
                     .foregroundColor(.secondary)
                     .padding(.top, 4)
                 if !cityName.isEmpty {
@@ -229,7 +229,7 @@ private struct QiblahCompassView: View {
                 .fill(Color.primary.opacity(0.05))
                 .frame(width: diameter, height: diameter)
             Circle()
-                .stroke(Color.primary.opacity(0.18), lineWidth: 2)
+                .stroke(Color.primary.opacity(0.28), lineWidth: 3.5)
                 .frame(width: diameter, height: diameter)
 
             // ── Tick marks (72 × 5° = 360°) ─────────────────────────
@@ -321,8 +321,8 @@ private struct QiblahCompassView: View {
 
             // ── Prayer mat — CENTERED, rotated to Qibla ─────────────
             // Mat is the centerpiece: the needle points from it toward Makkah.
-            let matW = r * 0.48
-            let matH = r * 0.64
+            let matW = r * 0.72
+            let matH = r * 0.96
             Image("PrayerMat")
                 .resizable()
                 .scaledToFit()
@@ -332,7 +332,7 @@ private struct QiblahCompassView: View {
                 .accessibilityLabel("Prayer mat facing Qiblah direction")
 
             // ── Ka'bah icon at ring edge ─────────────────────────────
-            let kaabahSize = r * 0.18
+            let kaabahSize = r * 0.36
             let kaabahR = r * 0.925
             Image("KaabahIcon")
                 .resizable()

--- a/iqamah/iOS/HilalWatchSheet.swift
+++ b/iqamah/iOS/HilalWatchSheet.swift
@@ -170,7 +170,6 @@
         }
 
         private func shareGrid() async {
-            // Build a simple text summary for iOS share (full image export is macOS-only in v1)
             let total = grid.count
             let aCount = grid.filter { $0 == Int8(VisibilityCategory.A.rawValue) }.count
             let pct = String(format: "%.0f%%", Double(aCount) / Double(total) * 100)
@@ -178,12 +177,27 @@
 
             await MainActor.run {
                 let vc = UIActivityViewController(activityItems: [text], applicationActivities: nil)
-                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                   let rootVC = windowScene.windows.first?.rootViewController {
-                    vc.popoverPresentationController?.sourceView = rootVC.view
-                    rootVC.present(vc, animated: true)
-                }
+                // Must present from the *topmost* view controller — presenting from the window
+                // root fails silently when a fullScreenCover is already active.
+                guard let presenter = topMostViewController() else { return }
+                vc.popoverPresentationController?.sourceView = presenter.view
+                vc.popoverPresentationController?.sourceRect = CGRect(
+                    x: presenter.view.bounds.midX, y: presenter.view.bounds.midY, width: 0, height: 0
+                )
+                presenter.present(vc, animated: true)
             }
+        }
+
+        private func topMostViewController() -> UIViewController? {
+            guard let scene = UIApplication.shared.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+                let root = scene.windows.first(where: \.isKeyWindow)?.rootViewController
+            else { return nil }
+            var top: UIViewController = root
+            while let presented = top.presentedViewController {
+                top = presented
+            }
+            return top
         }
     }
 #endif

--- a/iqamah/iOS/PrayerRowMobileView.swift
+++ b/iqamah/iOS/PrayerRowMobileView.swift
@@ -156,6 +156,7 @@
         let onToggleMute: () -> Void
 
         @Environment(\.colorScheme) private var colorScheme
+        @ObservedObject private var player = AdhaaanPlayer.shared
         private var gold: Color { colorScheme == .dark ? .appGold : .appGoldDark }
 
         private var isSunrise: Bool { prayerName == "Sunrise" }
@@ -178,6 +179,24 @@
 
         var body: some View {
             VStack(alignment: .leading, spacing: 8) {
+                // Stop preview button — shown while a sound is playing
+                if player.isPlaying {
+                    Button(action: { player.stop() }) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "stop.circle.fill")
+                                .font(.caption)
+                            Text("Stop preview")
+                                .font(.caption.weight(.semibold))
+                        }
+                        .foregroundStyle(gold)
+                        .padding(.horizontal, 10).padding(.vertical, 5)
+                        .background(Capsule().fill(gold.opacity(0.10)))
+                        .overlay(Capsule().strokeBorder(gold.opacity(0.25), lineWidth: 0.5))
+                    }
+                    .buttonStyle(.plain)
+                    .transition(.opacity.combined(with: .scale))
+                }
+
                 // Alert tones section
                 chipSection(
                     label: "🔔 Alert tones",
@@ -239,7 +258,12 @@
                             if adhaan.id == "silent" { return silentLabel ?? "No adhaan" }
                             return adhaan.shortName
                         }()
-                        Button(action: { onSelectAdhaan(adhaan) }) {
+                        Button(action: {
+                            // Play a preview so the user can hear before committing.
+                            // preview() ignores isMuted so it always sounds.
+                            AdhaaanPlayer.shared.preview(adhaan)
+                            onSelectAdhaan(adhaan)
+                        }) {
                             Text(displayName)
                                 .font(.caption.weight(.medium))
                                 .foregroundStyle(isSelected ? .white : accent)


### PR DESCRIPTION
Three iPhone UX fixes plus the Qibla compass visual refresh.

**HilalWatch share button** — `rootVC.present()` is silently ignored when a fullScreenCover is already active. Added `topMostViewController()` that walks `presentedViewController` to reach the actual topmost VC before presenting `UIActivityViewController`.

**Adhaan chip preview** — Tapping a chip now calls `AdhaaanPlayer.shared.preview(adhaan)` (plays sound regardless of mute state) before saving. A gold 'Stop preview' pill appears at the top of the tray while `player.isPlaying` is true, matching macOS behaviour.

**Qibla compass** — Prayer mat +50%, Kaaba icon +100%, bezel 2→3.5pt stroke, all tick marks heavier and longer (matching iPhone Compass weight), bearing subtitle upgraded to title3.

**Dynamic Island** — Requires the `@main` fix (PR #89) + a city to be set in Settings. After pulling both PRs, set a city, toggle Live Activity off then on.