### PR TITLE
fix: iOS in-app adhaan playback + ShareLink for HilalWatch export

### DIFF
--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -439,8 +439,48 @@ struct PrayerTimesView: View {
         } else {
             currentDate = newDate
         }
+
+        #if os(iOS)
+            // Mirror macOS AppDelegate.triggerAdhaanIfNeeded: play the selected adhaan
+            // when a prayer time arrives while the app is in the foreground.
+            triggerAdhaanIfNeeded(now: newDate)
+        #endif
     }
 }
+
+// MARK: - PrayerTimesView+AdhaanTrigger (iOS only)
+
+#if os(iOS)
+    private extension PrayerTimesView {
+        /// Set of "PrayerName-yyyy-MM-dd" keys already played today; reset at midnight.
+        static var announcedPrayers: Set<String> = []
+        static var announcedDate: Date = Date()
+
+        func triggerAdhaanIfNeeded(now: Date) {
+            guard let times = prayerTimes else { return }
+            let calendar = Calendar.current
+            if !calendar.isDate(now, inSameDayAs: Self.announcedDate) {
+                Self.announcedPrayers.removeAll()
+                Self.announcedDate = now
+            }
+            let tz = TimeZone(identifier: city.timezone) ?? .current
+            let fmt = DateFormatter(); fmt.dateFormat = "yyyy-MM-dd"; fmt.timeZone = tz
+            for prayer in times.prayers where prayer.name != "Sunrise" {
+                let adj = settingsStore.getAdjustment(for: prayer.name)
+                let adjusted = calendar.date(byAdding: .minute, value: adj, to: prayer.time) ?? prayer.time
+                let elapsed = now.timeIntervalSince(adjusted)
+                guard elapsed >= 0, elapsed < 90 else { continue }
+                let key = "\(prayer.name)-\(fmt.string(from: now))"
+                guard !Self.announcedPrayers.contains(key) else { continue }
+                Self.announcedPrayers.insert(key)
+                guard !settingsStore.isPrayerMuted(prayer.name) else { continue }
+                let adhaan = settingsStore.getAdhaan(for: prayer.name)
+                guard adhaan.id != "silent" else { continue }
+                AdhaaanPlayer.shared.play(adhaan)
+            }
+        }
+    }
+#endif
 
 // MARK: - PrayerTimesView+iPad Landscape
 

--- a/iqamah/iOS/HilalWatchSheet.swift
+++ b/iqamah/iOS/HilalWatchSheet.swift
@@ -52,9 +52,9 @@
                         Button("Done") { dismiss() }
                     }
                     ToolbarItemGroup(placement: .topBarTrailing) {
-                        Button {
-                            Task { await shareGrid() }
-                        } label: {
+                        // ShareLink uses SwiftUI's own sheet presentation — no UIKit
+                        // VC traversal needed, works correctly inside a fullScreenCover.
+                        ShareLink(item: shareText) {
                             Image(systemName: "square.and.arrow.up")
                         }
                         .accessibilityLabel("Share Hilal Map")
@@ -169,35 +169,12 @@
             }
         }
 
-        private func shareGrid() async {
+        /// Share text consumed by ShareLink — computed property so it always reflects current grid.
+        private var shareText: String {
             let total = grid.count
             let aCount = grid.filter { $0 == Int8(VisibilityCategory.A.rawValue) }.count
             let pct = String(format: "%.0f%%", Double(aCount) / Double(total) * 100)
-            let text = "Hilal Watch \u{00B7} \(selectedEvening == .d29 ? "29th" : "30th") Evening \u{00B7} \(pct) of globe easily visible \u{00B7} via Iqamah"
-
-            await MainActor.run {
-                let vc = UIActivityViewController(activityItems: [text], applicationActivities: nil)
-                // Must present from the *topmost* view controller — presenting from the window
-                // root fails silently when a fullScreenCover is already active.
-                guard let presenter = topMostViewController() else { return }
-                vc.popoverPresentationController?.sourceView = presenter.view
-                vc.popoverPresentationController?.sourceRect = CGRect(
-                    x: presenter.view.bounds.midX, y: presenter.view.bounds.midY, width: 0, height: 0
-                )
-                presenter.present(vc, animated: true)
-            }
-        }
-
-        private func topMostViewController() -> UIViewController? {
-            guard let scene = UIApplication.shared.connectedScenes
-                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-                let root = scene.windows.first(where: \.isKeyWindow)?.rootViewController
-            else { return nil }
-            var top: UIViewController = root
-            while let presented = top.presentedViewController {
-                top = presented
-            }
-            return top
+            return "Hilal Watch \u{00B7} \(selectedEvening == .d29 ? "29th" : "30th") Evening \u{00B7} \(pct) of globe easily visible \u{00B7} via Iqamah"
         }
     }
 #endif


### PR DESCRIPTION
Two iOS audio/share fixes.

**In-app adhaan playback** — The macOS app plays the adhaan in-app via AppDelegate.triggerAdhaanIfNeeded (60s timer). iOS had no equivalent — the notification fires but no audio plays when the app is in the foreground. Added PrayerTimesView+AdhaanTrigger (private extension, #if os(iOS)) with a 90-second trigger window and per-day deduplication, matching the macOS logic exactly.

Note: the notification sound for background playback requires a non-silent adhaan to be selected in the chip tray. The default 'No adhaan' = system ding only.

**HilalWatch share button** — UIActivityViewController presentation fails when SwiftUI's fullScreenCover is active because the UIKit VC hierarchy doesn't expose the fullscreen presenter as `presentedViewController`. Replaced with SwiftUI native ShareLink which uses SwiftUI's own presentation system with no UIKit traversal.