### PR TITLE
fix: iPad Hilal Watch layout — larger map, About card, header button

### DIFF
--- a/iqamah/Views/HilalWatch/AboutHilalWatchCard.swift
+++ b/iqamah/Views/HilalWatch/AboutHilalWatchCard.swift
@@ -3,8 +3,27 @@ import IqamahCore
 
 struct AboutHilalWatchCard: View {
     @Binding var isPresented: Bool
+    #if os(iOS)
+        @Environment(\.horizontalSizeClass) private var hSizeClass
+    #endif
 
     var body: some View {
+        // On iPad (.regular), expand to 640×740 so all three criteria fit without scrolling.
+        // On iPhone, keep the existing 400×500 to avoid overflowing the screen.
+        let cardWidth: CGFloat = {
+            #if os(iOS)
+                return hSizeClass == .regular ? 640 : 400
+            #else
+                return 400
+            #endif
+        }()
+        let cardHeight: CGFloat = {
+            #if os(iOS)
+                return hSizeClass == .regular ? 740 : 500
+            #else
+                return 500
+            #endif
+        }()
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 HStack {
@@ -50,7 +69,7 @@ struct AboutHilalWatchCard: View {
             }
             .padding(24)
         }
-        .frame(width: 400, height: 500)
+        .frame(width: cardWidth, height: cardHeight)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
     }
 

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -512,19 +512,30 @@ struct PrayerTimesView: View {
                     }
                     .frame(maxWidth: 150)
                     Spacer()
-                    MoonPhaseView(phase: currentMoonPhase, size: 32)
-                        .accessibilityHidden(true)
-                    VStack(alignment: .trailing, spacing: 1) {
-                        Text(hijriDateLabel)
-                            .font(.caption.weight(.medium))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
-                        Text(moonPhaseSubtitle)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
+                    // Moon + Hijri + Hilal Watch button grouped together
+                    HStack(spacing: 8) {
+                        MoonPhaseView(phase: currentMoonPhase, size: 32)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(hijriDateLabel)
+                                .font(.caption.weight(.medium))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.75)
+                            Text(moonPhaseSubtitle)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        .frame(maxWidth: 140)
+                        Button(action: openHilalWatch) {
+                            Text("Hilal Watch ›")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Color.appGoldDim)
+                                .padding(.horizontal, 8).padding(.vertical, 4)
+                                .background(Capsule().fill(Color.appGoldDim.opacity(0.10)))
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .frame(maxWidth: 140)
                     if let nextTime = nextPrayerTime {
                         VStack(alignment: .trailing, spacing: 1) {
                             Text(nextTime, style: .timer)
@@ -563,13 +574,6 @@ struct PrayerTimesView: View {
                                 )
                                 .padding(.horizontal, 12).padding(.bottom, 12)
                             }
-                            Button(action: openHilalWatch) {
-                                Label("Hilal Watch", systemImage: "moon.haze.fill")
-                                    .font(.caption.weight(.semibold))
-                                    .foregroundStyle(Color.appGoldDim)
-                            }
-                            .buttonStyle(.plain)
-                            .padding(.horizontal, 16).padding(.bottom, 12)
                         }
                     }
                     .frame(maxWidth: .infinity)

--- a/iqamah/iOS/HilalWatchSheet.swift
+++ b/iqamah/iOS/HilalWatchSheet.swift
@@ -8,6 +8,7 @@
     struct HilalWatchSheet: View {
         @EnvironmentObject private var settings: SettingsManager
         @Environment(\.dismiss) private var dismiss
+        @Environment(\.horizontalSizeClass) private var hSizeClass
         @ObservedObject private var preloader = HilalWatchPreloader.shared
         @State private var selectedEvening: Evening = .d29
         @State private var selectedCriterion: HilalCriterionPicker.CriterionChoice = .odeh
@@ -96,10 +97,10 @@
                     }
                 }
 
-                // Global crescent visibility map
+                // Global crescent visibility map — taller on iPad for better legibility
                 Section("Global Visibility") {
                     HilalMapView(grid: grid)
-                        .frame(height: 220)
+                        .frame(height: hSizeClass == .regular ? 380 : 220)
                         .listRowInsets(EdgeInsets())
                         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }


### PR DESCRIPTION
Three iPad layout improvements for Hilal Watch.

**Map height** — portrait map now 380pt on iPad vs 220pt on iPhone, adapting via horizontalSizeClass. The map was too short on iPad to be useful.

**About card** — expands to 640×740 on iPad so all three criterion descriptions fit without scrolling. iPhone keeps 400×500.

**Landscape Hilal Watch button** — moved from isolated bottom corner of Today column into the header HStack, grouped with the MoonPhaseView and Hijri date label. More discoverable and semantically grouped with the moon data it leads to.