### PR TITLE
fix: macOS adhaan picker broken + show-window deminiaturize

### DIFF
--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -338,7 +338,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // The Dock icon temporarily appears — this is expected macOS behaviour for
         // hybrid menu-bar/window apps (same pattern used by Bartender, Fantastical, etc.).
         NSApplication.shared.setActivationPolicy(.regular)
-        resolvedMainWindow?.makeKeyAndOrderFront(nil)
+        if let window = resolvedMainWindow {
+            // Un-minimise if needed — makeKeyAndOrderFront alone doesn't restore from Dock
+            if window.isMiniaturized { window.deminiaturize(nil) }
+            window.makeKeyAndOrderFront(nil)
+        }
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
 

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -277,11 +277,16 @@ struct PrayerTimesView: View {
                     Rectangle().fill(.ultraThinMaterial.opacity(0.6))
                 }
 
-            // Prayer times table
+            // Prayer times table — pass the shared expandedRowID so the adhaan
+            // picker can open/close on macOS (was using .constant(nil) default).
             if let prayerTimes {
-                PrayerTimesTable(prayerTimes: prayerTimes, timezone: TimeZone(identifier: city.timezone) ?? .current)
-                    .padding(.horizontal, 24)
-                    .padding(.bottom, 24)
+                PrayerTimesTable(
+                    prayerTimes: prayerTimes,
+                    timezone: TimeZone(identifier: city.timezone) ?? .current,
+                    expandedRowID: $expandedRowID
+                )
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
             } else {
                 ProgressView()
                     .padding(.vertical, 40)


### PR DESCRIPTION
**Adhaan picker not responding**: The macOS PrayerTimesTable was called with the convenience init default expandedRowID: .constant(nil). This binding is immutable so onTogglePicker's assignment was silently discarded. Now passes $expandedRowID from the view's @State property.

**'Open Main Window' requires dock click**: makeKeyAndOrderFront doesn't restore a miniaturized window — deminiaturize(nil) is needed first. Added isMiniaturized check.