### PR TITLE
feat: US-0066 macOS XCUITest suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Enforce ≥75% domain coverage
         run: |
-          EXCLUDED="Views/|AppDelegate|ContentView|iqamahApp|AppIconGenerator|AppIconView|LocationService|AdhaaanPlayer"
+          EXCLUDED="Views/|AppDelegate|ContentView|iqamahApp|AppIconGenerator|AppIconView|LocationService|AdhaaanPlayer|UITests"
           COVERAGE=$(xcrun xccov view --report --json TestResults.xcresult 2>/dev/null \
             | python3 -c "import sys,json,re; d=json.load(sys.stdin); ex=sys.argv[1]; files=[f for t in d.get('targets',[]) for f in t.get('files',[]) if not re.search(ex,f.get('path',''))]; te=sum(f.get('executableLines',0) for f in files); tc=sum(f.get('coveredLines',0) for f in files); print(f'{(tc/te*100) if te>0 else 0:.1f}')" "$EXCLUDED" \
             2>/dev/null || echo "0")

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -119,6 +119,42 @@ jobs:
           path: /tmp/smoke-watch-build.log
           retention-days: 3
 
+  # ── macOS XCUITests (US-0066) ────────────────────────────────────────────────
+  # Runs only in nightly (AC-0325).  Uses --uitesting launch arg to seed Toronto
+  # settings; CODE_SIGN_IDENTITY="-" skips distribution signing in CI.
+  ui-tests-macos:
+    name: XCUITest · macOS
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Run macOS XCUITests
+        run: |
+          xcodebuild test \
+            -project iqamah.xcodeproj \
+            -scheme iqamah \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -only-testing:iqamahUITests \
+            CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+            ENABLE_HARDENED_RUNTIME=NO \
+            2>&1 | tee /tmp/uitests.log \
+            | grep -E "error:|Test (Case|Suite) '|passed|failed|BUILD" | tail -30
+
+      - name: Upload XCUITest log on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: xcuitest-macos-log
+          path: /tmp/uitests.log
+          retention-days: 3
+
   # ── Summary ─────────────────────────────────────────────────────────────────
   # This job always runs last and posts a Markdown summary to the Actions tab.
   # fail-fast: false on the matrix means individual platform failures are
@@ -126,7 +162,7 @@ jobs:
   summary:
     name: Nightly Summary
     runs-on: ubuntu-latest
-    needs: [smoke-macos, smoke-ios, smoke-ipad, smoke-watch]
+    needs: [smoke-macos, smoke-ios, smoke-ipad, smoke-watch, ui-tests-macos]
     if: always()
     steps:
       - name: Write summary
@@ -135,7 +171,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Platform | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          for platform_job in "macOS:smoke-macos" "iPhone:smoke-ios" "iPad:smoke-ipad" "watchOS:smoke-watch"; do
+          for platform_job in "macOS:smoke-macos" "iPhone:smoke-ios" "iPad:smoke-ipad" "watchOS:smoke-watch" "XCUITest macOS:ui-tests-macos"; do
             name="${platform_job%%:*}"
             result="${{ needs[platform_job##*:].result }}"
             icon="✅" && [[ "$result" != "success" ]] && icon="❌"

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		UITESTS0000000000000005 /* IqamahUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = UITESTS0000000000000004 /* IqamahUITests.swift */; };
 		944B0D992F635A0500EC6A01 /* TestsAdditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944B0D982F635A0500EC6A01 /* TestsAdditionalTests.swift */; };
 		94594CE62FB2C01D00D1AD1C /* IqamahCore in Frameworks */ = {isa = PBXBuildFile; productRef = IC0000000000000000000002 /* IqamahCore */; };
 		94CAD5652F23CBB800E1689F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CAD5642F23CBB800E1689F /* AppDelegate.swift */; };
@@ -110,6 +111,13 @@
 		/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		UITESTS0000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AA0000000000000000000050 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AA0000000000000000000040;
+			remoteInfo = iqamah;
+		};
 		EE0000000000000000007001 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AA0000000000000000000050 /* Project object */;
@@ -174,6 +182,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		UITESTS0000000000000003 /* iqamahUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iqamahUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		UITESTS0000000000000004 /* IqamahUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IqamahUITests.swift; sourceTree = "<group>"; };
 		944B0D7D2F6340DD00EC6A01 /* AGENTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = AGENTS.md; sourceTree = "<group>"; };
 		944B0D8C2F63423600EC6A01 /* .env.example */ = {isa = PBXFileReference; lastKnownFileType = text; path = .env.example; sourceTree = "<group>"; };
 		944B0D8D2F63424C00EC6A01 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
@@ -287,6 +297,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		UITESTS0000000000000007 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AA0000000000000000000020 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -363,6 +380,7 @@
 				WA000000000000000000070 /* IqamahWatch */,
 				WW000000000000000000070 /* IqamahWatchWidget */,
 				WT000000000000000000070 /* IqamahWatchTests */,
+				UITESTS0000000000000009 /* iqamahUITests */,
 				AA0000000000000000000032 /* Products */,
 				9457D7C42F2BDF2D00549E92 /* AppIconView.swift */,
 				9457D7C52F2BDF6400549E92 /* AppIconGenerator.swift */,
@@ -372,6 +390,14 @@
 				944B0DB92F63689C00EC6A01 /* docs */,
 				944B0DD42F646FFC00EC6A01 /* testsIqamahTests_FIXED.swift */,
 			);
+			sourceTree = "<group>";
+		};
+		UITESTS0000000000000009 /* iqamahUITests */ = {
+			isa = PBXGroup;
+			children = (
+				UITESTS0000000000000004 /* IqamahUITests.swift */,
+			);
+			path = iqamahUITests;
 			sourceTree = "<group>";
 		};
 		AA0000000000000000000031 /* iqamah */ = {
@@ -404,6 +430,7 @@
 			children = (
 				AA0000000000000000000010 /* iqamah.app */,
 				EE0000000000000000001001 /* iqamahTests.xctest */,
+				UITESTS0000000000000003 /* iqamahUITests.xctest */,
 				iOS0000000000000000000015 /* iqamah-iOS.app */,
 				LA000000000000000000005 /* IqamahLiveActivity.appex */,
 				WG000000000000000000042 /* IqamahWidget.appex */,
@@ -570,6 +597,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		UITESTS000000000000000A /* iqamahUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UITESTS000000000000000D /* Build configuration list for PBXNativeTarget "iqamahUITests" */;
+			buildPhases = (
+				UITESTS0000000000000006 /* Sources */,
+				UITESTS0000000000000007 /* Frameworks */,
+				UITESTS0000000000000008 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				UITESTS0000000000000002 /* PBXTargetDependency */,
+			);
+			name = iqamahUITests;
+			productName = iqamahUITests;
+			productReference = UITESTS0000000000000003 /* iqamahUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		AA0000000000000000000040 /* iqamah */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AA0000000000000000000060 /* Build configuration list for PBXNativeTarget "iqamah" */;
@@ -794,6 +839,7 @@
 				WA000000000000000000001 /* IqamahWatch */,
 				AA0000000000000000000040 /* iqamah */,
 				EE0000000000000000001000 /* iqamahTests */,
+				UITESTS000000000000000A /* iqamahUITests */,
 				iOS0000000000000000000040 /* iqamah-iOS */,
 				WG000000000000000000001 /* IqamahWidget */,
 				MW00000000000000000001 /* IqamahWidgetMac */,
@@ -802,6 +848,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		UITESTS0000000000000008 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AA0000000000000000000042 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -860,6 +913,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		UITESTS0000000000000006 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UITESTS0000000000000005 /* IqamahUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AA0000000000000000000041 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -997,6 +1058,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		UITESTS0000000000000002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AA0000000000000000000040 /* iqamah */;
+			targetProxy = UITESTS0000000000000001 /* PBXContainerItemProxy */;
+		};
 		EE0000000000000000007002 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = AA0000000000000000000040 /* iqamah */;
@@ -1025,6 +1091,34 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		UITESTS000000000000000B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.fablesoft.iqamah.uitests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = iqamah;
+			};
+			name = Debug;
+		};
+		UITESTS000000000000000C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.fablesoft.iqamah.uitests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = iqamah;
+			};
+			name = Release;
+		};
 		AA0000000000000000000052 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1558,6 +1652,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		UITESTS000000000000000D /* Build configuration list for PBXNativeTarget "iqamahUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UITESTS000000000000000B /* Debug */,
+				UITESTS000000000000000C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		AA0000000000000000000051 /* Build configuration list for PBXProject "iqamah" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/iqamah.xcodeproj/xcshareddata/xcschemes/iqamah.xcscheme
+++ b/iqamah.xcodeproj/xcshareddata/xcschemes/iqamah.xcscheme
@@ -35,6 +35,20 @@
                ReferencedContainer = "container:iqamah.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UITESTS000000000000000A"
+               BuildableName = "iqamahUITests.xctest"
+               BlueprintName = "iqamahUITests"
+               ReferencedContainer = "container:iqamah.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -52,6 +66,16 @@
                BlueprintIdentifier = "EE0000000000000000001000"
                BuildableName = "iqamahTests.xctest"
                BlueprintName = "iqamahTests"
+               ReferencedContainer = "container:iqamah.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UITESTS000000000000000A"
+               BuildableName = "iqamahUITests.xctest"
+               BlueprintName = "iqamahUITests"
                ReferencedContainer = "container:iqamah.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -18,6 +18,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var announcedDate = Date()
 
     func applicationDidFinishLaunching(_: Notification) {
+        // Bootstrap UI test state before any other setup so SettingsManager
+        // reads the seeded city when ContentView first renders.
+        if CommandLine.arguments.contains("--uitesting") {
+            bootstrapUITestSettings()
+        }
+
         // Start as a menu-bar-only agent (no dock icon, no Cmd+Tab).
         // We do this in code rather than via LSUIElement in the plist so that
         // setActivationPolicy(.regular) works fully when the window is shown.
@@ -75,6 +81,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    // MARK: - UI Test bootstrap
+
+    /// Pre-seeds Toronto / ISNA settings so XCUITests start on the prayer times view.
+    /// Called only when launched with the `--uitesting` argument (AC-0317, US-0066).
+    private func bootstrapUITestSettings() {
+        let toronto = try? IqamahCore.City(
+            name: "Toronto",
+            countryCode: "CA",
+            latitude: 43.6534,
+            longitude: -79.3834,
+            timezone: "America/Toronto"
+        )
+        if let city = toronto {
+            SettingsManager.shared.completeSetup(
+                city: city,
+                calculationMethod: .isna,
+                asrMethod: .standard
+            )
+        }
+    }
+
     private func setupStatusBarItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
@@ -82,6 +109,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             button.action = #selector(statusBarButtonClicked)
             button.target = self
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+            // Accessibility identifier used by XCUITests (AC-0318 / AC-0319)
+            button.setAccessibilityIdentifier("iqamahStatusBarButton")
         }
 
         updateStatusBarDisplay()

--- a/iqamah/Views/PrayerTimesComponents.swift
+++ b/iqamah/Views/PrayerTimesComponents.swift
@@ -429,6 +429,8 @@ struct PrayerTimeRow: View {
         .accessibilityLabel(selectedAdhaan.id == "silent"
             ? "No adhaan set for \(name). Tap to set."
             : "Adhaan for \(name): \(selectedAdhaan.displayName). Tap to change.")
+        // XCUITest identifier (AC-0323, US-0066)
+        .accessibilityIdentifier("adhaanPill-\(name)")
     }
 
     private var mainRowContent: some View {
@@ -597,6 +599,8 @@ struct PrayerTimeRow: View {
                                         ? effectiveGold : .secondary)
                             }
                             .buttonStyle(.plain)
+                            // XCUITest identifier (AC-0323, US-0066)
+                            .accessibilityIdentifier("adhaanOption-\(option.id)")
                         }
                     }
                     .padding(.horizontal, 2)

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -259,6 +259,8 @@ struct PrayerTimesView: View {
                 .buttonStyle(.borderless)
                 .font(.caption.weight(.medium))
                 .foregroundStyle(Color.appGold)
+                // XCUITest identifier (AC-0322, US-0066)
+                .accessibilityIdentifier("hilalWatchButton")
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
@@ -540,6 +542,7 @@ struct PrayerTimesView: View {
                                 .background(Capsule().fill(Color.appGoldDim.opacity(0.10)))
                         }
                         .buttonStyle(.plain)
+                        .accessibilityIdentifier("hilalWatchButton")
                     }
                     if let nextTime = nextPrayerTime {
                         VStack(alignment: .trailing, spacing: 1) {

--- a/iqamah/Views/SettingsSheetView.swift
+++ b/iqamah/Views/SettingsSheetView.swift
@@ -412,6 +412,8 @@ struct SettingsSheetView: View {
                     .buttonStyle(.bordered)
                     .controlSize(.large)
                     .keyboardShortcut(.escape, modifiers: [])
+                    // XCUITest identifier (AC-0324, US-0066)
+                    .accessibilityIdentifier("settingsCancelButton")
 
                     Spacer()
 

--- a/iqamahUITests/IqamahUITests.swift
+++ b/iqamahUITests/IqamahUITests.swift
@@ -1,0 +1,185 @@
+// IqamahUITests.swift
+// AC-0317–AC-0325 (US-0066, EPIC-0015)
+//
+// macOS XCUITest suite covering:
+//   - Status bar menu interactions
+//   - Main window lifecycle
+//   - Hilal Watch window opening
+//   - Adhaan picker expand / collapse
+//   - Settings sheet open / cancel
+//
+// All tests launch the app with "--uitesting" which pre-seeds Toronto/ISNA
+// settings so the prayer times view is shown immediately after the 1-second
+// splash.  Tests are designed to complete in under 60 seconds in aggregate.
+
+import XCTest
+
+// MARK: - IqamahUITests
+
+final class IqamahUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    // MARK: setUp / tearDown
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["--uitesting"]
+        app.launch()
+        // Splash auto-advances in 1 s when setup is complete; give it 3 s for CI headroom.
+        _ = app.staticTexts["Fajr"].waitForExistence(timeout: 6)
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    // MARK: - AC-0318: Left-click opens popover
+
+    func testStatusBarLeftClickOpensPopover() {
+        let statusItem = app.statusItems.firstMatch
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 3),
+                      "Status bar item should be present after launch")
+
+        let windowsBefore = app.windows.count
+        statusItem.click()
+
+        // The popover appears as an additional window in the app's window list.
+        let appeared = app.windows.count > windowsBefore ||
+            app.windows.firstMatch.waitForExistence(timeout: 2)
+        XCTAssertTrue(appeared, "A popover or window should appear after left-clicking the status item")
+
+        // Dismiss by clicking elsewhere so subsequent tests start clean.
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    // MARK: - AC-0319: Right-click shows menu with required items
+
+    func testStatusBarRightClickShowsMenu() {
+        let statusItem = app.statusItems.firstMatch
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 3))
+
+        statusItem.rightClick()
+
+        XCTAssertTrue(app.menuItems["Open Main Window"].waitForExistence(timeout: 2),
+                      "'Open Main Window' should appear in the right-click menu")
+        XCTAssertTrue(app.menuItems["Moon Sighting\u{2026}"].exists,
+                      "'Moon Sighting…' should appear in the right-click menu")
+        XCTAssertTrue(app.menuItems["Settings"].exists,
+                      "'Settings' should appear in the right-click menu")
+        XCTAssertTrue(app.menuItems["Quit Iqamah"].exists,
+                      "'Quit Iqamah' should appear in the right-click menu")
+
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    // MARK: - AC-0320: "Open Main Window" brings prayer times window forward
+
+    func testOpenMainWindowFromMenu() {
+        let statusItem = app.statusItems.firstMatch
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 3))
+
+        statusItem.rightClick()
+        app.menuItems["Open Main Window"].click()
+
+        // The main window should be visible and should NOT be the Hilal Watch window.
+        let mainWindow = app.windows.firstMatch
+        XCTAssertTrue(mainWindow.waitForExistence(timeout: 3),
+                      "Main window should appear after 'Open Main Window'")
+        XCTAssertFalse(mainWindow.title.contains("Hilal"),
+                       "The opened window should not be the Hilal Watch window")
+    }
+
+    // MARK: - AC-0321: "Moon Sighting…" opens Hilal Watch window
+
+    func testHilalWatchOpensFromMenu() {
+        let statusItem = app.statusItems.firstMatch
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 3))
+
+        statusItem.rightClick()
+        app.menuItems["Moon Sighting\u{2026}"].click()
+
+        // Hilal Watch window should appear.
+        let hilalWindow = app.windows["Hilal Watch"]
+        XCTAssertTrue(hilalWindow.waitForExistence(timeout: 4),
+                      "Hilal Watch window should open from the menu")
+    }
+
+    // MARK: - AC-0322: "Hilal Watch ›" button in prayer view opens Hilal Watch
+
+    func testHilalWatchOpensFromDetailsButton() {
+        // Ensure main window is open first.
+        let statusItem = app.statusItems.firstMatch
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 3))
+        statusItem.rightClick()
+        app.menuItems["Open Main Window"].click()
+        _ = app.windows.firstMatch.waitForExistence(timeout: 3)
+
+        // The "Hilal Watch ›" button has accessibility identifier "hilalWatchButton".
+        let hilalBtn = app.buttons["hilalWatchButton"]
+        XCTAssertTrue(hilalBtn.waitForExistence(timeout: 4),
+                      "'Hilal Watch ›' button should be present in the main window")
+        hilalBtn.click()
+
+        let hilalWindow = app.windows["Hilal Watch"]
+        XCTAssertTrue(hilalWindow.waitForExistence(timeout: 4),
+                      "Hilal Watch window should open after clicking 'Hilal Watch ›'")
+    }
+
+    // MARK: - AC-0323: Adhaan picker expands and collapses
+
+    func testAdhaanPickerOpenAndClose() {
+        let statusItem = app.statusItems.firstMatch
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 3))
+        statusItem.rightClick()
+        app.menuItems["Open Main Window"].click()
+        _ = app.windows.firstMatch.waitForExistence(timeout: 3)
+
+        // Click the Fajr adhaan pill — it should expand the picker.
+        let fajrPill = app.buttons["adhaanPill-Fajr"]
+        XCTAssertTrue(fajrPill.waitForExistence(timeout: 4),
+                      "Fajr adhaan pill should exist in the prayer table")
+        fajrPill.click()
+
+        // The picker rows become visible; look for any adhaan option label.
+        // We expect the picker to show at least one selectable option.
+        let pickerVisible = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH 'adhaanOption-'")).firstMatch
+            .waitForExistence(timeout: 2)
+        XCTAssertTrue(pickerVisible, "Adhaan options should appear after clicking the Fajr pill")
+
+        // Click a different prayer pill — Fajr picker should collapse.
+        let dhuhrPill = app.buttons["adhaanPill-Dhuhr"]
+        XCTAssertTrue(dhuhrPill.waitForExistence(timeout: 2))
+        dhuhrPill.click()
+
+        // Dhuhr picker is now open; Fajr picker should be gone.
+        XCTAssertFalse(
+            app.buttons["adhaanPill-Fajr"].isSelected,
+            "Fajr picker should collapse when a different row is tapped"
+        )
+    }
+
+    // MARK: - AC-0324: Settings sheet opens and Cancel closes it without saving
+
+    func testSettingsSheetOpensAndCloses() {
+        let statusItem = app.statusItems.firstMatch
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 3))
+        statusItem.rightClick()
+
+        // Open Settings via the menu.
+        app.menuItems["Settings"].click()
+
+        // The settings sheet should appear (it's presented as a SwiftUI .sheet).
+        // The Cancel button has accessibilityIdentifier "settingsCancelButton".
+        let cancelBtn = app.buttons["settingsCancelButton"]
+        XCTAssertTrue(cancelBtn.waitForExistence(timeout: 4),
+                      "Settings Cancel button should be visible after opening Settings")
+
+        cancelBtn.click()
+
+        // Sheet should dismiss — Cancel button gone, prayer times view visible again.
+        XCTAssertFalse(cancelBtn.waitForExistence(timeout: 2),
+                       "Settings sheet should close after tapping Cancel")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **`iqamahUITests` target** (UI testing bundle, macOS) with 7 test cases covering AC-0317–AC-0325
- **`--uitesting` launch arg** in `AppDelegate` pre-seeds Toronto/ISNA settings via `SettingsManager.completeSetup` so tests immediately land on the prayer times view (no splash/setup flows)
- **Accessibility identifiers** added to key elements: `adhaanPill-{name}`, `adhaanOption-{id}`, `hilalWatchButton`, `settingsCancelButton`, `iqamahStatusBarButton`
- **nightly.yml** gets a new `ui-tests-macos` job (xcodebuild test -only-testing:iqamahUITests); PR CI is unaffected (testable marked `skipped=YES` in scheme)

## Tests added (AC-0317–AC-0325)

| Test | AC |
|---|---|
| `testStatusBarLeftClickOpensPopover` | AC-0318 |
| `testStatusBarRightClickShowsMenu` | AC-0319 |
| `testOpenMainWindowFromMenu` | AC-0320 |
| `testHilalWatchOpensFromMenu` | AC-0321 |
| `testHilalWatchOpensFromDetailsButton` | AC-0322 |
| `testAdhaanPickerOpenAndClose` | AC-0323 |
| `testSettingsSheetOpensAndCloses` | AC-0324 |

## Test plan

- [ ] CI passes (PR pipeline excludes XCUITests per AC-0325)
- [ ] After merge: trigger nightly `workflow_dispatch` to verify `ui-tests-macos` job runs green