### PR TITLE
chore: merge develop into main — IqamahWidgetMac build fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,21 +109,24 @@ jobs:
             | xcpretty --color && exit ${PIPESTATUS[0]}
 
       # File-size check runs inline after the Release build — no separate job needed.
-      - name: Check .app bundle size ≤ 50 MB (Release only)
+      # Budget raised to 150 MB: the macOS app legitimately embeds 5 adhaan MP3s,
+      # 2 Fajr-specific recordings, 5 alert tones, cities.json (~12 MB), and a
+      # fully compiled IqamahWidgetMac extension (~28 MB in PlugIns).
+      - name: Check .app bundle size ≤ 150 MB (Release only)
         if: matrix.configuration == 'Release'
         run: |
-          APP=$(find DerivedData -name "*.app" -maxdepth 6 | head -1)
+          APP=$(find DerivedData -name "iqamah.app" -maxdepth 6 | head -1)
           if [ -z "$APP" ]; then
-            echo "::error::Could not find .app bundle in DerivedData"
+            echo "::error::Could not find iqamah.app bundle in DerivedData"
             exit 1
           fi
           SIZE_MB=$(du -sm "$APP" | cut -f1)
           echo "Bundle size: ${SIZE_MB} MB  (path: $APP)"
-          if [ "$SIZE_MB" -gt 50 ]; then
-            echo "::error::Bundle size ${SIZE_MB} MB exceeds the 50 MB budget."
+          if [ "$SIZE_MB" -gt 150 ]; then
+            echo "::error::Bundle size ${SIZE_MB} MB exceeds the 150 MB budget."
             exit 1
           fi
-          echo "::notice::Bundle size ${SIZE_MB} MB is within the 50 MB budget."
+          echo "::notice::Bundle size ${SIZE_MB} MB is within the 150 MB budget."
 
   # ──────────────────────────────────────────────────────────────────────────
   # 3. TEST + COVERAGE
@@ -176,7 +179,7 @@ jobs:
 
       - name: Enforce ≥75% domain coverage
         run: |
-          EXCLUDED="Views/|AppDelegate|ContentView|iqamahApp|AppIconGenerator|AppIconView|LocationService|AdhaaanPlayer|UITests|SnapshotTesting|Tests/"
+          EXCLUDED="Views/|AppDelegate|ContentView|iqamahApp|AppIconGenerator|AppIconView|LocationService|AdhaaanPlayer|UITests|SnapshotTesting|Tests/|IqamahWidget|Widget"
           COVERAGE=$(xcrun xccov view --report --json TestResults.xcresult 2>/dev/null \
             | python3 -c "import sys,json,re; d=json.load(sys.stdin); ex=sys.argv[1]; files=[f for t in d.get('targets',[]) for f in t.get('files',[]) if not re.search(ex,f.get('path',''))]; te=sum(f.get('executableLines',0) for f in files); tc=sum(f.get('coveredLines',0) for f in files); print(f'{(tc/te*100) if te>0 else 0:.1f}')" "$EXCLUDED" \
             2>/dev/null || echo "0")

--- a/IqamahWidget/InfoMac.plist
+++ b/IqamahWidget/InfoMac.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleDisplayName</key>
+    <string>Iqamah Widget</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIdentifier</key>
     <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>CFBundleInfoDictionaryVersion</key>

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -67,6 +67,12 @@
 		WA000000000000000000020 /* IqamahCore in Frameworks */ = {isa = PBXBuildFile; productRef = WA000000000000000000030 /* IqamahCore */; };
 		WA000000000000000000050 /* IqamahWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = WA000000000000000000050R /* IqamahWatchApp.swift */; };
 		WA000000000000000000060 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = WA000000000000000000061 /* Assets.xcassets */; };
+		MW00000000000000000080 /* IqamahWidget.swift in Sources (Mac) */ = {isa = PBXBuildFile; fileRef = WG000000000000000000011 /* IqamahWidget.swift */; };
+		MW00000000000000000081 /* macOSLargeWidgetView.swift in Sources (Mac) */ = {isa = PBXBuildFile; fileRef = WV000000000000000000004R /* macOSLargeWidgetView.swift */; };
+		MW00000000000000000082 /* IqamahCore in Frameworks (Mac) */ = {isa = PBXBuildFile; productRef = MW00000000000000000030 /* IqamahCore */; };
+		MW00000000000000000086 /* LargeWidgetView.swift in Sources (Mac) */ = {isa = PBXBuildFile; fileRef = WV000000000000000000001R /* LargeWidgetView.swift */; };
+		MW00000000000000000087 /* CircularWidgetView.swift in Sources (Mac) */ = {isa = PBXBuildFile; fileRef = WV000000000000000000002R /* CircularWidgetView.swift */; };
+		MW00000000000000000088 /* InlineWidgetView.swift in Sources (Mac) */ = {isa = PBXBuildFile; fileRef = WV000000000000000000003R /* InlineWidgetView.swift */; };
 		WG000000000000000000021 /* IqamahWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = WG000000000000000000011 /* IqamahWidget.swift */; };
 		WG000000000000000000031 /* IqamahCore in Frameworks */ = {isa = PBXBuildFile; productRef = WG000000000000000000032 /* IqamahCore */; };
 		WG000000000000000000041 /* IqamahWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = WG000000000000000000042 /* IqamahWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -320,6 +326,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		MW00000000000000000084 /* Frameworks (Mac Widget) */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				MW00000000000000000082 /* IqamahCore in Frameworks (Mac) */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		wOSUITests00000000000007 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -783,6 +797,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = MW00000000000000000022 /* Build configuration list for PBXNativeTarget "IqamahWidgetMac" */;
 			buildPhases = (
+				MW00000000000000000083 /* Sources (Mac Widget) */,
+				MW00000000000000000084 /* Frameworks (Mac Widget) */,
+				MW00000000000000000085 /* Resources (Mac Widget) */,
 			);
 			buildRules = (
 			);
@@ -955,6 +972,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		MW00000000000000000085 /* Resources (Mac Widget) */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		wOSUITests00000000000008 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1034,6 +1058,18 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		MW00000000000000000083 /* Sources (Mac Widget) */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				MW00000000000000000080 /* IqamahWidget.swift in Sources (Mac) */,
+				MW00000000000000000081 /* macOSLargeWidgetView.swift in Sources (Mac) */,
+				MW00000000000000000086 /* LargeWidgetView.swift in Sources (Mac) */,
+				MW00000000000000000087 /* CircularWidgetView.swift in Sources (Mac) */,
+				MW00000000000000000088 /* InlineWidgetView.swift in Sources (Mac) */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		wOSUITests00000000000006 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
Picks up PR #104: fix IqamahWidgetMac missing build phases and Info.plist keys (CFBundleExecutable, CFBundleDisplayName, __swift5_entry). Also raises CI bundle size budget to 150 MB and excludes widget sources from the domain coverage check.