### PR TITLE
fix: add CFBundleDisplayName to iOS extension Info.plist files

### DIFF
--- a/IqamahLiveActivity/Info.plist
+++ b/IqamahLiveActivity/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Iqamah</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/IqamahWidget/Info.plist
+++ b/IqamahWidget/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Iqamah Widget</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
App Store Connect validation requires `CFBundleDisplayName` (code 90360) in all extension bundles. Both iOS extensions were missing it:
- `IqamahWidget/Info.plist` → added `CFBundleDisplayName = Iqamah Widget`
- `IqamahLiveActivity/Info.plist` → added `CFBundleDisplayName = Iqamah`

`CFBundleExecutable` and `__swift5_entry` are both present and correct in these targets — only the display name was missing.