### PR TITLE
fix: widget shows stale prayer + app stuck on old NEXT after background

### DIFF
--- a/IqamahWidget/IqamahWidget.swift
+++ b/IqamahWidget/IqamahWidget.swift
@@ -49,10 +49,32 @@ struct PrayerTimelineProvider: TimelineProvider {
 
     func getTimeline(in _: Context, completion: @escaping (Timeline<PrayerEntry>) -> Void) {
         let now = Date()
-        let entry = makeEntry(for: now)
-        // Refresh after next prayer time (or in 1 hour if no prayer found)
-        let nextRefresh = entry.nextPrayerTime > now ? entry.nextPrayerTime : now.addingTimeInterval(3600)
-        completion(Timeline(entries: [entry], policy: .after(nextRefresh)))
+
+        // Generate one entry per prayer transition for today + tomorrow.
+        // WidgetKit reads entries from local cache at the right moment — no
+        // background wake needed. Using .atEnd asks WidgetKit to call
+        // getTimeline again once all entries expire (after tomorrow's last prayer).
+        var entries: [PrayerEntry] = [makeEntry(for: now)] // "right now" entry
+
+        let settings = SettingsManager.shared
+        if let coord = settings.activeCoordinate,
+           let timezone = TimeZone(identifier: settings.activeTimezoneIdentifier) {
+            let calc = PrayerCalculator(
+                coordinate: coord, timezone: timezone,
+                method: settings.calculationMethod, asrMethod: settings.asrMethod
+            )
+            for dayOffset in 0 ... 1 {
+                guard let day = Calendar.current.date(byAdding: .day, value: dayOffset, to: now),
+                      let times = try? calc.calculate(for: day)
+                else { continue }
+                for prayer in times.prayers where prayer.name != "Sunrise" && prayer.time > now {
+                    // Each entry becomes active exactly when that prayer starts.
+                    entries.append(makeEntry(for: prayer.time))
+                }
+            }
+        }
+
+        completion(Timeline(entries: entries, policy: .atEnd))
     }
 
     private func makeEntry(for date: Date) -> PrayerEntry {
@@ -198,12 +220,12 @@ struct IqamahWidget: Widget {
     // iOS/iPadOS also support ExtraLarge and lock-screen accessory families.
     private static var supportedFamilies: [WidgetFamily] {
         #if os(macOS)
-        return [.systemSmall, .systemMedium, .systemLarge]
+            return [.systemSmall, .systemMedium, .systemLarge]
         #else
-        return [
-            .systemSmall, .systemMedium, .systemLarge, .systemExtraLarge,
-            .accessoryRectangular, .accessoryCircular, .accessoryInline,
-        ]
+            return [
+                .systemSmall, .systemMedium, .systemLarge, .systemExtraLarge,
+                .accessoryRectangular, .accessoryCircular, .accessoryInline,
+            ]
         #endif
     }
 

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
@@ -6,6 +6,8 @@ public extension Notification.Name {
     static let settingsDidChange = Notification.Name("settingsDidChange")
     static let openSettings = Notification.Name("openSettings")
     static let openHilalWatch = Notification.Name("openHilalWatch")
+    /// Posted when the app returns to foreground so prayer-time views recalculate.
+    static let refreshPrayerTimes = Notification.Name("refreshPrayerTimes")
 }
 
 public enum AppAppearance: String, CaseIterable {

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -330,6 +330,14 @@ struct PrayerTimesView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openSettings)) { _ in
             showSettings = true
         }
+        // Recalculate when the app returns to foreground so "NEXT" label
+        // reflects the current time even after a long background session.
+        .onReceive(NotificationCenter.default.publisher(for: .refreshPrayerTimes)) { _ in
+            currentDate = Date()
+            calculatePrayerTimes()
+            timerSubscription?.cancel()
+            timerSubscription = timer.connect()
+        }
     }
 
     // MARK: - Next Prayer Helpers (iOS)

--- a/iqamah/iOS/iqamahApp_iOS.swift
+++ b/iqamah/iOS/iqamahApp_iOS.swift
@@ -50,6 +50,9 @@ struct IqamahiOSApp: App {
                 .onChange(of: scenePhase) { _, phase in
                     if phase == .active {
                         reschedule()
+                        reloadWidget()
+                        // Tell PrayerTimesView to recalculate so "NEXT" label is current
+                        NotificationCenter.default.post(name: .refreshPrayerTimes, object: nil)
                         // Pre-compute Hilal grid in background so sheet opens instantly
                         HilalWatchPreloader.shared.prefetch(settings: settings)
                         if settings.liveActivityEnabled {


### PR DESCRIPTION
## Bugs fixed

**Lock screen widget shows stale Fajr at 9:39am**
Single-entry timeline + `.after(nextPrayerTime)` policy requires WidgetKit to wake for a refresh. WidgetKit has a fixed daily budget (~40-70 calls) and won't fire at an exact moment while the device sleeps.

**Fix:** generate one `PrayerEntry` per prayer transition for today + tomorrow. WidgetKit picks the correct entry from local cache at each prayer time — no background wake needed. Uses `.atEnd` policy so the timeline is refreshed daily.

**App stuck showing "NEXT: Fajr" after returning from background**
The 60-second timer stops in background. When the app became active, nothing forced `PrayerTimesView` to recalculate.

**Fix:** when `scenePhase → .active`, post `.refreshPrayerTimes` notification + call `reloadWidget()`. `PrayerTimesView` observes the notification, resets `currentDate`, recalculates prayer times, and reconnects the timer.