### PR TITLE
feat: macOS UI polish — Hilal Watch header, map labels, nav buttons, popover moon

### DIFF
--- a/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
@@ -8,6 +8,7 @@ public extension Notification.Name {
     static let openHilalWatch = Notification.Name("openHilalWatch")
     /// Posted when the app returns to foreground so prayer-time views recalculate.
     static let refreshPrayerTimes = Notification.Name("refreshPrayerTimes")
+    static let openAbout = Notification.Name("openAbout")
 }
 
 public enum AppAppearance: String, CaseIterable {

--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -331,6 +331,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         settingsItem.target = self
         menu.addItem(settingsItem)
 
+        let aboutItem = NSMenuItem(title: "About Iqamah", action: #selector(openAboutFromMenu), keyEquivalent: "")
+        aboutItem.target = self
+        menu.addItem(aboutItem)
+
         menu.addItem(NSMenuItem.separator())
 
         let quitItem = NSMenuItem(title: "Quit Iqamah", action: #selector(quitApp), keyEquivalent: "q")
@@ -424,6 +428,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         showWindow()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             NotificationCenter.default.post(name: .openSettings, object: nil)
+        }
+    }
+
+    @objc func openAboutFromMenu() {
+        showWindow()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            NotificationCenter.default.post(name: .openAbout, object: nil)
         }
     }
 

--- a/iqamah/Views/HilalWatch/HilalMapView.swift
+++ b/iqamah/Views/HilalWatch/HilalMapView.swift
@@ -9,7 +9,15 @@ import IqamahCore
 
         func makeNSView(context: Context) -> MKMapView {
             let map = MKMapView()
-            map.mapType = .mutedStandard
+            // MKStandardMapConfiguration with .default emphasis renders continent
+            // labels in bold black instead of the muted-standard pink/light style.
+            if #available(macOS 13.0, *) {
+                let config = MKStandardMapConfiguration(elevationStyle: .flat)
+                config.emphasisStyle = .default
+                map.preferredConfiguration = config
+            } else {
+                map.mapType = .mutedStandard
+            }
             map.delegate = context.coordinator
             return map
         }

--- a/iqamah/Views/HilalWatch/HilalWatchView.swift
+++ b/iqamah/Views/HilalWatch/HilalWatchView.swift
@@ -72,43 +72,63 @@ struct HilalWatchView: View {
 
     // MARK: - Header
 
+    private func pickerLabel(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .tracking(0.5)
+    }
+
     private var header: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 16) {
+            // Title block
+            VStack(alignment: .leading, spacing: 3) {
                 Text("Hilal Watch")
-                    .font(.headline)
+                    .font(.system(size: 24, weight: .semibold))
                 Text(monthLabel)
-                    .font(.caption)
+                    .font(.callout)
                     .foregroundStyle(.secondary)
             }
 
             Spacer()
 
-            // Evening tab picker
-            Picker("Evening", selection: $selectedEvening) {
-                Text("29th").tag(Evening.d29)
-                Text("30th").tag(Evening.d30)
+            // Evening picker — label above buttons
+            VStack(spacing: 4) {
+                pickerLabel("Evening")
+                Picker("", selection: $selectedEvening) {
+                    Text("29th").tag(Evening.d29)
+                    Text("30th").tag(Evening.d30)
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 120)
             }
-            .pickerStyle(.segmented)
-            .frame(maxWidth: 120)
 
-            HilalCriterionPicker(selectedCriterion: $selectedCriterion)
-
-            Button {
-                showShareSheet = true
-            } label: {
-                Image(systemName: "square.and.arrow.up")
+            // Criterion picker — label above buttons
+            VStack(spacing: 4) {
+                pickerLabel("Criterion")
+                HilalCriterionPicker(selectedCriterion: $selectedCriterion)
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Share Hilal Map")
 
-            Button {
-                withAnimation { showAbout.toggle() }
-            } label: {
-                Image(systemName: "info.circle")
+            // Action buttons
+            HStack(spacing: 10) {
+                Button {
+                    showShareSheet = true
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 14))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Share Hilal Map")
+
+                Button {
+                    withAnimation { showAbout.toggle() }
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 14))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("About Hilal Watch")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("About Hilal Watch")
         }
     }
 

--- a/iqamah/Views/MenuBarPopoverView.swift
+++ b/iqamah/Views/MenuBarPopoverView.swift
@@ -61,6 +61,18 @@ struct MenuBarPopoverView: View {
 
             Spacer()
 
+            // Moon phase — shown between countdown and mute button
+            VStack(spacing: 3) {
+                MoonPhaseView(phase: currentMoonPhase, size: 32)
+                    .accessibilityLabel("Current moon phase")
+                Text(moonPhaseLabel)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                    .tracking(0.4)
+                    .lineLimit(1)
+            }
+
             VStack(spacing: 3) {
                 Button(action: { AdhaaanPlayer.shared.toggleMute() }) {
                     Image(systemName: player.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
@@ -165,6 +177,27 @@ struct MenuBarPopoverView: View {
     }
 
     // MARK: Helpers
+
+    /// Synodic phase [0, 1) based on days since last new moon.
+    private var currentMoonPhase: Double {
+        let newMoon = NewMoon.previous(before: Date())
+        let daysSince = max(0, Date().timeIntervalSince(newMoon)) / 86400
+        return (daysSince / 29.53).truncatingRemainder(dividingBy: 1.0)
+    }
+
+    private var moonPhaseLabel: String {
+        let phase = currentMoonPhase
+        switch phase {
+        case 0.0 ..< 0.03, 0.97...: return "New"
+        case 0.03 ..< 0.22: return "Waxing"
+        case 0.22 ..< 0.28: return "1st Qtr"
+        case 0.28 ..< 0.47: return "Waxing"
+        case 0.47 ..< 0.53: return "Full"
+        case 0.53 ..< 0.72: return "Waning"
+        case 0.72 ..< 0.78: return "3rd Qtr"
+        default: return "Waning"
+        }
+    }
 
     private var cityMethodLine: String {
         let city = settings.locationSource == "gps" && !settings.gpsLocality.isEmpty

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -186,7 +186,38 @@ struct PrayerTimesView: View {
 
                 Spacer()
 
-                // Mute — the one action important enough for the primary header
+                // ── Qiblah / Settings / About — in header on macOS ──
+                #if os(macOS)
+                    HStack(spacing: 2) {
+                        Button(action: { showQiblah = true }) {
+                            Image(systemName: "location.north.line.fill")
+                                .font(.title3)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Qiblah direction")
+                        .accessibilityLabel("Show Qiblah direction")
+
+                        Button(action: { showSettings = true }) {
+                            Image(systemName: "gearshape")
+                                .font(.title3)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Settings")
+                        .accessibilityLabel("Open settings")
+                        .keyboardShortcut(",", modifiers: .command)
+
+                        Button(action: { showAbout = true }) {
+                            Image(systemName: "info.circle")
+                                .font(.title3)
+                        }
+                        .buttonStyle(.plain)
+                        .help("About Iqamah")
+                        .accessibilityLabel("About Iqamah")
+                    }
+                    .padding(.trailing, 8)
+                #endif
+
+                // Mute button
                 Button(action: { AdhaaanPlayer.shared.toggleMute() }) {
                     Image(systemName: AdhaaanPlayer.shared.isMuted
                         ? "speaker.slash.fill" : "speaker.wave.2.fill")
@@ -201,39 +232,6 @@ struct PrayerTimesView: View {
             .padding(.horizontal, 22)
             .padding(.top, 16)
             .padding(.bottom, 10)
-            .background {
-                Rectangle().fill(.ultraThinMaterial)
-            }
-
-            // ── Secondary toolbar: navigation actions + Hijri date ───
-            // On iOS, Qiblah and Settings are in the tab bar — only About is unique here.
-            HStack(spacing: 0) {
-                #if os(macOS)
-                    SecondaryToolbarButton(
-                        label: "Qiblah",
-                        systemImage: "location.north.line.fill",
-                        action: { showQiblah = true }
-                    )
-                    .accessibilityLabel("Show Qiblah direction")
-
-                    SecondaryToolbarButton(
-                        label: "Settings",
-                        systemImage: "gearshape",
-                        action: { showSettings = true }
-                    )
-                    .accessibilityLabel("Open settings")
-                    .keyboardShortcut(",", modifiers: .command)
-                #endif
-
-                SecondaryToolbarButton(
-                    label: "About",
-                    systemImage: "info.circle",
-                    action: { showAbout = true }
-                )
-                .accessibilityLabel("About Iqamah")
-
-                Spacer()
-            }
             .background {
                 Rectangle().fill(.ultraThinMaterial)
             }
@@ -329,6 +327,9 @@ struct PrayerTimesView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .openSettings)) { _ in
             showSettings = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openAbout)) { _ in
+            showAbout = true
         }
         // Recalculate when the app returns to foreground so "NEXT" label
         // reflects the current time even after a long background session.


### PR DESCRIPTION
## Changes

**Hilal Watch header layout**
- "Evening" and "Criterion" labels now sit **above** their respective segmented pickers (horizontal, not vertical)
- Title enlarged from `.headline` → `system(24, .semibold)` (~50% bigger)
- Subtitle enlarged from `.caption` → `.callout` (~50% bigger)

**Map continent labels**
- Use `MKStandardMapConfiguration(emphasisStyle: .default)` on macOS 13+ so continent labels render in **bold black** instead of muted pink

**macOS main window navigation**
- Qiblah / Settings / About icon buttons moved from the secondary toolbar strip into the **primary header row**, beside the Mute button — freeing a full row of vertical space

**Right-click menu**
- **"About Iqamah"** added to the menu before the Quit separator

**Menu bar left-click popover**
- **Moon phase icon + phase name** added between the countdown block and the mute button

## Deferred (separate PRs)
- GPS city persistence + detected city name shown in dropdowns/headers (IqamahCore change needed)
- Compass Done button focus-loss fix
- Dynamic Island / Mac notch (iOS-only feature, not applicable to Mac)