### PR TITLE
fix: widget gold text adapts to light/dark mode

### DIFF
--- a/IqamahWidget/CircularWidgetView.swift
+++ b/IqamahWidget/CircularWidgetView.swift
@@ -4,7 +4,13 @@ import WidgetKit
 
 struct CircularWidgetView: View {
     let entry: PrayerEntry
-    private let gold = Color(red: 1.0, green: 0.839, blue: 0.039)
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var gold: Color {
+        colorScheme == .dark
+            ? Color(red: 0.88, green: 0.69, blue: 0.06)
+            : Color(red: 0.54, green: 0.37, blue: 0.00)
+    }
 
     var body: some View {
         ZStack {

--- a/IqamahWidget/LargeWidgetView.swift
+++ b/IqamahWidget/LargeWidgetView.swift
@@ -4,7 +4,14 @@ import WidgetKit
 
 struct LargeWidgetView: View {
     let entry: PrayerEntry
-    private let gold = Color(red: 1.0, green: 0.839, blue: 0.039)
+    @Environment(\.colorScheme) private var colorScheme
+
+    // Matches Color.appGold (dark) / Color.appGoldDark (light) from the main app.
+    private var gold: Color {
+        colorScheme == .dark
+            ? Color(red: 0.88, green: 0.69, blue: 0.06)
+            : Color(red: 0.54, green: 0.37, blue: 0.00)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/IqamahWidget/macOSLargeWidgetView.swift
+++ b/IqamahWidget/macOSLargeWidgetView.swift
@@ -5,7 +5,13 @@
 
     struct macOSLargeWidgetView: View {
         let entry: PrayerEntry
-        private let gold = Color(red: 1.0, green: 0.839, blue: 0.039)
+        @Environment(\.colorScheme) private var colorScheme
+
+        private var gold: Color {
+            colorScheme == .dark
+                ? Color(red: 0.88, green: 0.69, blue: 0.06)
+                : Color(red: 0.54, green: 0.37, blue: 0.00)
+        }
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
All three widget views (`LargeWidgetView`, `macOSLargeWidgetView`, `CircularWidgetView`) used a hardcoded bright yellow-gold that looked fine in dark mode but was washed out in light mode.

Added `@Environment(\.colorScheme)` to each view. The `gold` computed property now returns:
- **Dark** → `Color(0.88, 0.69, 0.06)` ≈ `Color.appGold`  
- **Light** → `Color(0.54, 0.37, 0.00)` ≈ `Color.appGoldDark`

Matches the same light/dark gold convention used throughout the rest of the app.