### PR TITLE
fix: add SKIP_INSTALL=YES to IqamahWatch — resolves iOS Generic archive

### DIFF
--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -1737,6 +1737,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.watch;
 				PRODUCT_NAME = IqamahWatch;
 				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.10;
 				WATCHOS_DEPLOYMENT_TARGET = 10.0;
 			};
@@ -1755,6 +1756,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.watch;
 				PRODUCT_NAME = IqamahWatch;
 				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.10;
 				WATCHOS_DEPLOYMENT_TARGET = 10.0;
 			};


### PR DESCRIPTION
Without `SKIP_INSTALL=YES`, Xcode tries to install the `IqamahWatch` watchOS binary as a top-level product in the iOS archive, which fails — a watchOS binary cannot be a standalone iOS archive product. The entire archive degrades to **Generic Xcode Archive**, hiding the version, app icon, and blocking App Store upload.

With `SKIP_INSTALL=YES`, Xcode treats `IqamahWatch` as embedded-only. The **Embed Watch Content** build phase on `iqamah-iOS` still copies it into `$(CONTENTS_FOLDER_PATH)/Watch/IqamahWatch.app`, producing a proper **iOS App Archive**.