### PR TITLE
fix: remove WKWatchOnly from IqamahWatch — companion app, not independent

### DIFF
--- a/IqamahWatch/Info.plist
+++ b/IqamahWatch/Info.plist
@@ -11,16 +11,14 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
+    <string>$(MARKETING_VERSION)</string>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>Iqamah uses your location to calculate accurate prayer times on your wrist.</string>
     <key>NSMotionUsageDescription</key>
     <string>Iqamah uses the compass to show the Qibla direction.</string>
     <key>WKApplication</key>
-    <true/>
-    <key>WKWatchOnly</key>
     <true/>
 </dict>
 </plist>

--- a/iqamah.xcodeproj/xcshareddata/xcschemes/IqamahWatch.xcscheme
+++ b/iqamah.xcodeproj/xcshareddata/xcschemes/IqamahWatch.xcscheme
@@ -53,7 +53,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "wOSUITests0000000000000A"


### PR DESCRIPTION
Validation error 90753 on App Store Connect upload.

`WKWatchOnly = true` tells Apple the watch app is **fully independent** (runs without the iPhone). When present, Apple requires the iOS container app to declare `LSApplicationLaunchProhibited = true` and `ITSWatchOnlyContainer = true` — which we don't want.

**IqamahWatch is a companion app**: it uses `WatchConnectivity` to sync city, calculation method, and prayer times from the paired iPhone. Removing `WKWatchOnly` (defaults to `false`) correctly declares it as a companion.

Also fixed hardcoded `CFBundleVersion = 1` / `CFBundleShortVersionString = 1.0` → `$(CURRENT_PROJECT_VERSION)` / `$(MARKETING_VERSION)` so the watch app correctly reports version 1.5.0 (build 10).