### PR TITLE
fix: add WKCompanionAppBundleIdentifier to IqamahWatch Info.plist (error 90536)

### DIFF
--- a/IqamahWatch/Info.plist
+++ b/IqamahWatch/Info.plist
@@ -20,5 +20,7 @@
     <string>Iqamah uses the compass to show the Qibla direction.</string>
     <key>WKApplication</key>
     <true/>
+    <key>WKCompanionAppBundleIdentifier</key>
+    <string>com.fablesoft.iqamah</string>
 </dict>
 </plist>


### PR DESCRIPTION
Companion watchOS apps must declare which iOS app they pair with via `WKCompanionAppBundleIdentifier`. After removing `WKWatchOnly` (PR #119, error 90753), Apple validates this companion linkage key is present.

Added `WKCompanionAppBundleIdentifier = com.fablesoft.iqamah` to `IqamahWatch/Info.plist`.