### PR TITLE
fix: detect already-granted location permission on watchOS

### DIFF
--- a/IqamahWatch/IqamahWatchApp.swift
+++ b/IqamahWatch/IqamahWatchApp.swift
@@ -74,7 +74,21 @@ final class WatchLocationSetup: NSObject, ObservableObject, CLLocationManagerDel
         }
         manager.delegate = self
         manager.desiredAccuracy = kCLLocationAccuracyKilometer
-        manager.requestWhenInUseAuthorization()
+
+        // If permission is already granted, requestWhenInUseAuthorization() is a no-op
+        // and the delegate callback may not fire — so check the current status explicitly
+        // and call requestLocation() directly when already authorised.
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            manager.requestLocation()
+        case .denied, .restricted:
+            statusMessage = "Enable location in Watch Settings"
+            isReady = true
+            return
+        default: // .notDetermined — show the permission prompt
+            manager.requestWhenInUseAuthorization()
+        }
+
         // Watchdog: if GPS hasn't resolved after 20 s (simulator or denied), mark ready
         // so the user lands on prayer times with a "select location in Settings" prompt.
         Task {


### PR DESCRIPTION
When the user had previously granted location access, `requestWhenInUseAuthorization()` was a no-op and the delegate callback `locationManagerDidChangeAuthorization` did not reliably fire — so `requestLocation()` was never called, the 20-second watchdog expired, and the watch showed the 'select city in Settings' fallback even though permission was already granted.

**Fix:** Check `manager.authorizationStatus` explicitly before deciding what to call:
- Already authorized → `requestLocation()` immediately
- Not determined → `requestWhenInUseAuthorization()` (existing behaviour, shows prompt)
- Denied/restricted → mark ready with error message immediately (no watchdog needed)

The delegate callback still handles the transition from not-determined → authorized.