### PR TITLE
fix: show GPS locality name in iOS/watchOS headers and Qibla; reload prayers on city change

### DIFF
--- a/IqamahWatch/PrayerTimesTab.swift
+++ b/IqamahWatch/PrayerTimesTab.swift
@@ -33,6 +33,9 @@ struct PrayerTimesTab: View {
         .onAppear { loadPrayers() }
         .onChange(of: settings.calculationMethod) { _, _ in loadPrayers() }
         .onChange(of: settings.asrMethod) { _, _ in loadPrayers() }
+        // Reload when city changes (manual selection or GPS update)
+        .onChange(of: settings.locationSource) { _, _ in loadPrayers() }
+        .onChange(of: settings.gpsLocality) { _, _ in loadPrayers() }
     }
 
     private func formattedTime(_ date: Date) -> String {

--- a/IqamahWatch/SettingsTab.swift
+++ b/IqamahWatch/SettingsTab.swift
@@ -88,7 +88,8 @@ struct SettingsTab: View {
     }
 
     private var locationLabel: String {
-        if let city = settings.loadCity() { return city.name }
+        let name = settings.activeCityName // GPS locality or nearest city name
+        if !name.isEmpty { return name }
         if let coord = settings.activeCoordinate {
             return String(format: "%.2f°, %.2f°", coord.latitude, coord.longitude)
         }

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -24,6 +24,12 @@ struct PrayerTimesView: View {
     // AC-0064: scale the serif title with the user's Dynamic Type size preference
     @ScaledMetric(relativeTo: .title3) private var titleFontSize: CGFloat = 28
 
+    /// GPS locality name when active, otherwise the nearest mapped city name.
+    private var displayCityName: String {
+        let name = settingsStore.activeCityName
+        return name.isEmpty ? city.name : name
+    }
+
     private let timer = Timer.publish(every: 60, on: .main, in: .common)
 
     // MARK: - Body
@@ -109,7 +115,7 @@ struct PrayerTimesView: View {
                         startPoint: .topLeading, endPoint: .bottomTrailing
                     ))
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(city.name)
+                    Text(displayCityName)
                         .font(.title3.weight(.semibold))
                         .lineLimit(1)
                         .minimumScaleFactor(0.85)
@@ -174,7 +180,7 @@ struct PrayerTimesView: View {
                     )
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(city.name)
+                    Text(displayCityName)
                         .font(.title3.weight(.semibold))
                         .lineLimit(1)
                         .minimumScaleFactor(0.85)
@@ -296,7 +302,7 @@ struct PrayerTimesView: View {
         }
         .frame(minWidth: 580, idealWidth: 620, minHeight: 640, idealHeight: 680)
         .sheet(isPresented: $showQiblah) {
-            QiblahView(latitude: city.latitude, longitude: city.longitude, cityName: city.name)
+            QiblahView(latitude: city.latitude, longitude: city.longitude, cityName: displayCityName)
         }
         .sheet(isPresented: $showSettings) {
             SettingsSheetView(
@@ -517,7 +523,7 @@ struct PrayerTimesView: View {
                             startPoint: .topLeading, endPoint: .bottomTrailing
                         ))
                     VStack(alignment: .leading, spacing: 1) {
-                        Text(city.name)
+                        Text(displayCityName)
                             .font(.callout.weight(.semibold))
                             .lineLimit(1)
                             .minimumScaleFactor(0.75)

--- a/iqamah/iOS/iOSRootView.swift
+++ b/iqamah/iOS/iOSRootView.swift
@@ -55,7 +55,8 @@ struct MainTabView: View {
 
             NavigationStack {
                 if let city {
-                    QiblahView(latitude: city.latitude, longitude: city.longitude, cityName: city.name)
+                    QiblahView(latitude: city.latitude, longitude: city.longitude,
+                               cityName: settings.activeCityName.isEmpty ? city.name : settings.activeCityName)
                 } else {
                     Text("Select a location first")
                         .foregroundStyle(.secondary)


### PR DESCRIPTION
Four related fixes for GPS city name display and watchOS city-change reactivity:

**iOS/macOS PrayerTimesView + iOSRootView:**
- Add `displayCityName` computed property that returns `settings.activeCityName` (GPS locality e.g. 'Brampton') when GPS is active, else `city.name` (nearest mapped city e.g. 'Toronto')
- Replace `city.name` → `displayCityName` in iOS and macOS primary headers
- Replace `cityName: city.name` → `displayCityName` for the Qibla compass

**watchOS PrayerTimesTab:**
- Add `.onChange(of: settings.locationSource)` and `.onChange(of: settings.gpsLocality)` observers so prayer times recalculate when a city is manually set or GPS updates. Previously only `calculationMethod`/`asrMethod` changes triggered a reload — manual city selection had no visible effect on the prayer times tab.

**watchOS SettingsTab:**
- `locationLabel` uses `settings.activeCityName` instead of `settings.loadCity()?.name` so it shows the GPS locality ('Brampton') not the nearest mapped city ('Toronto')