### PR TITLE
fix: drop non-Sendable settings capture in watch CLGeocoder Task closure

### DIFF
--- a/IqamahWatch/IqamahWatchApp.swift
+++ b/IqamahWatch/IqamahWatchApp.swift
@@ -145,8 +145,16 @@ final class WatchLocationSetup: NSObject, ObservableObject, CLLocationManagerDel
             }
             let locality = placemark.locality ?? placemark.name ?? ""
             let timezone = placemark.timeZone?.identifier ?? TimeZone.current.identifier
+            // Reach SettingsManager via `.shared` inside the @MainActor body rather
+            // than capturing the local `settings` parameter — the CLGeocoder
+            // completion handler runs on an arbitrary queue and the implicit
+            // @Sendable Task closure would otherwise capture a non-Sendable
+            // SettingsManager reference (Swift 6 concurrency warning).
             Task { @MainActor in
-                settings.applyGeocodingRefinement(locality: locality, timezoneIdentifier: timezone)
+                SettingsManager.shared.applyGeocodingRefinement(
+                    locality: locality,
+                    timezoneIdentifier: timezone
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
Xcode 26 / Swift 6 surfaced two concurrency warnings on `IqamahWatchApp.swift`:
- *Add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'IqamahCore'*
- *Capture of 'settings' with non-Sendable type 'SettingsManager' in a '@Sendable' closure*

Both originated from the ENH-001 Task 2 watch CLGeocoder refinement (PR #129). The implicit `@Sendable Task` closure inside the CLGeocoder completion captured the `settings: SettingsManager` parameter. `SettingsManager` is a class-backed ObservableObject and not Sendable.

## Fix
Access `SettingsManager.shared` inside the `@MainActor` body instead of capturing the local `settings` parameter. Strings (locality, timezone) are already Sendable and cross fine. No behavior change — `settings` at the call site is always `SettingsManager.shared` anyway.

## Test plan
- [x] `IqamahWatch` scheme builds clean — zero Sendable warnings
- [ ] On a real watch / sim, GPS detect still populates `gpsLocality` and `gpsTimezone` via CLGeocoder

🤖 Generated with [Claude Code](https://claude.com/claude-code)