### PR TITLE
feat(core): Fasting Mode foundation (Tasks 1–9 of EPIC-0017)

### DIFF
--- a/IqamahLiveActivity/Info.plist
+++ b/IqamahLiveActivity/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>15</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/IqamahLiveActivity/Info.plist
+++ b/IqamahLiveActivity/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/IqamahWatch/Info.plist
+++ b/IqamahWatch/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>14</string>
+    <string>1</string>
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>NSLocationWhenInUseUsageDescription</key>

--- a/IqamahWatch/Info.plist
+++ b/IqamahWatch/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>15</string>
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>NSLocationWhenInUseUsageDescription</key>

--- a/IqamahWidget/Info.plist
+++ b/IqamahWidget/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>15</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/IqamahWidget/Info.plist
+++ b/IqamahWidget/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/IqamahWidget/InfoMac.plist
+++ b/IqamahWidget/InfoMac.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>15</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/IqamahWidget/InfoMac.plist
+++ b/IqamahWidget/InfoMac.plist
@@ -17,7 +17,7 @@
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>14</string>
+    <string>1</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/Packages/IqamahCore/Sources/IqamahCore/Models/CalculationMethod.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Models/CalculationMethod.swift
@@ -7,6 +7,7 @@ public enum CalculationMethod: String, CaseIterable, Identifiable {
     case ummAlQura = "umm_al_qura"
     case karachi
     case tehran
+    case jafari
 
     public var id: String { rawValue }
 
@@ -24,6 +25,8 @@ public enum CalculationMethod: String, CaseIterable, Identifiable {
             "University of Islamic Sciences, Karachi"
         case .tehran:
             "Institute of Geophysics, University of Tehran"
+        case .jafari:
+            "Ja'fari (Shia outside Iran)"
         }
     }
 
@@ -36,6 +39,7 @@ public enum CalculationMethod: String, CaseIterable, Identifiable {
         case .ummAlQura: "Umm Al-Qura"
         case .karachi: "Karachi"
         case .tehran: "Tehran"
+        case .jafari: "Ja'fari"
         }
     }
 
@@ -53,6 +57,8 @@ public enum CalculationMethod: String, CaseIterable, Identifiable {
             18.0
         case .tehran:
             17.7
+        case .jafari:
+            16.0
         }
     }
 
@@ -70,6 +76,8 @@ public enum CalculationMethod: String, CaseIterable, Identifiable {
             18.0
         case .tehran:
             14.0
+        case .jafari:
+            14.0
         }
     }
 
@@ -86,6 +94,8 @@ public enum CalculationMethod: String, CaseIterable, Identifiable {
         switch self {
         case .tehran:
             4.5
+        case .jafari:
+            4.0
         default:
             nil
         }
@@ -117,6 +127,12 @@ extension CalculationMethod {
     public static func recommendationLabel(forCountryCode code: String) -> String? {
         let name = Locale.current.localizedString(forRegionCode: code)
         return name.map { "Recommended for \($0)" }
+    }
+
+    /// True for methods rooted in Ja'fari (Shia) jurisprudence.
+    /// Drives tradition-aware UI gating in Fasting Mode.
+    public var isShiaMethod: Bool {
+        self == .tehran || self == .jafari
     }
 }
 

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingLabelFormatter.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingLabelFormatter.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Pure helpers for relabeling prayer-name strings when Fasting Mode is active.
+/// Consumed by every narrow surface (menu bar, watch, widgets, Live Activity).
+public enum FastingLabelFormatter {
+
+    /// Window (in seconds) before a prayer time during which the Suhoor/Iftar
+    /// relabel applies. 2 hours per spec.
+    private static let relabelWindow: TimeInterval = 2 * 60 * 60
+
+    /// Relabel a prayer name when Fasting Mode is active and the prayer is within 2h.
+    /// Returns the original name if any precondition fails (inactive, prohibition,
+    /// outside window, or non-Fajr/non-Maghrib prayer).
+    public static func relabel(
+        prayerName: String,
+        prayerTime: Date,
+        currentTime: Date,
+        state: FastingDayState
+    ) -> String {
+        guard state.isActive, state.trigger != nil else { return prayerName }
+
+        let newLabel: String
+        switch prayerName {
+        case "Fajr": newLabel = "Suhoor"
+        case "Maghrib": newLabel = "Iftar"
+        default: return prayerName
+        }
+
+        let secondsUntil = prayerTime.timeIntervalSince(currentTime)
+        guard (0...Self.relabelWindow).contains(secondsUntil) else { return prayerName }
+
+        let glyph: String = state.trigger == .autoRamadan ? "🌙" : "🕗"
+
+        return "\(glyph) \(newLabel)"
+    }
+}

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingMode.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingMode.swift
@@ -124,6 +124,34 @@ public struct FastingModeSettings: Codable, Equatable {
         self.notificationsEnabled = notificationsEnabled
     }
 
+    // MARK: - Forward-compatible decoding
+    //
+    // Synthesized Codable throws `keyNotFound` for any absent field, which would
+    // break users upgrading from an earlier version whose persisted JSON predates
+    // a newly-added field. Decode each field with `decodeIfPresent` and fall back
+    // to the same defaults the memberwise `init(...)` uses.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            enabled: try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false,
+            autoRamadan: try c.decodeIfPresent(Bool.self, forKey: .autoRamadan) ?? true,
+            weeklyDays: try c.decodeIfPresent(Set<Int>.self, forKey: .weeklyDays) ?? [],
+            ayyamAlBeed: try c.decodeIfPresent(Bool.self, forKey: .ayyamAlBeed) ?? false,
+            sixDaysShawwal: try c.decodeIfPresent(Bool.self, forKey: .sixDaysShawwal) ?? false,
+            dayOfArafah: try c.decodeIfPresent(Bool.self, forKey: .dayOfArafah) ?? false,
+            firstNineDhulHijjah: try c.decodeIfPresent(Bool.self, forKey: .firstNineDhulHijjah) ?? false,
+            muharramFast: try c.decodeIfPresent(Bool.self, forKey: .muharramFast) ?? false,
+            midShaban: try c.decodeIfPresent(Bool.self, forKey: .midShaban) ?? false,
+            mabath: try c.decodeIfPresent(Bool.self, forKey: .mabath) ?? false,
+            suhoorLeadMinutes: try c.decodeIfPresent(Int.self, forKey: .suhoorLeadMinutes) ?? 30,
+            iftarLeadMinutes: try c.decodeIfPresent(Int.self, forKey: .iftarLeadMinutes) ?? 15,
+            dayBeforeEnabled: try c.decodeIfPresent(Bool.self, forKey: .dayBeforeEnabled) ?? true,
+            dayBeforeHour: try c.decodeIfPresent(Int.self, forKey: .dayBeforeHour) ?? 20,
+            dayBeforeMinute: try c.decodeIfPresent(Int.self, forKey: .dayBeforeMinute) ?? 0,
+            notificationsEnabled: try c.decodeIfPresent(Bool.self, forKey: .notificationsEnabled) ?? true
+        )
+    }
+
     /// Friday in weeklyDays without Thursday or Saturday — discouraged in many traditions.
     public var hasFridayAloneWarning: Bool {
         weeklyDays.contains(6) && !weeklyDays.contains(5) && !weeklyDays.contains(7)

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingMode.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingMode.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// Result of evaluating today against the user's Fasting Mode settings.
+/// Pure-data; computed by FastingModeEngine; consumed by every surface.
+public struct FastingDayState: Equatable, Codable, Hashable {
+    /// Is today a fasting day (after prohibition filter)?
+    public let isActive: Bool
+    /// Why today is active. Nil when isActive == false.
+    public let trigger: FastingTriggerKind?
+    /// Hard-prohibited override. When non-nil, isActive is false regardless of triggers.
+    public let prohibition: ProhibitedDay?
+    /// The day this state describes (midnight in the evaluation timezone).
+    public let date: Date
+
+    public init(
+        isActive: Bool,
+        trigger: FastingTriggerKind?,
+        prohibition: ProhibitedDay?,
+        date: Date
+    ) {
+        self.isActive = isActive
+        self.trigger = trigger
+        self.prohibition = prohibition
+        self.date = date
+    }
+
+    /// Convenience constructor for the inactive case.
+    public static func inactive(date: Date) -> FastingDayState {
+        FastingDayState(isActive: false, trigger: nil, prohibition: nil, date: date)
+    }
+}
+
+public enum FastingTriggerKind: String, Codable, Hashable, CaseIterable {
+    case autoRamadan
+    case weeklySchedule
+    case ayyamAlBeed
+    case sixDaysShawwal
+    case dayOfArafah
+    case firstNineDhulHijjah
+    case muharramFast
+    case midShaban
+    case mabath
+}
+
+public enum ProhibitedDay: String, Codable, Hashable, CaseIterable {
+    case eidAlFitr // 1 Shawwal
+    case eidAlAdha // 10 Dhul-Hijjah
+    case tashriq11 // 11 Dhul-Hijjah
+    case tashriq12 // 12 Dhul-Hijjah
+    case tashriq13 // 13 Dhul-Hijjah
+
+    public var displayName: String {
+        switch self {
+        case .eidAlFitr: "Eid al-Fitr"
+        case .eidAlAdha: "Eid al-Adha"
+        case .tashriq11: "11 Dhul-Hijjah (Tashriq)"
+        case .tashriq12: "12 Dhul-Hijjah (Tashriq)"
+        case .tashriq13: "13 Dhul-Hijjah (Tashriq)"
+        }
+    }
+}
+
+/// User-configurable Fasting Mode settings, persisted as a single JSON blob
+/// in UserDefaults under Keys.fastingModeSettings and KVS-synced.
+public struct FastingModeSettings: Codable, Equatable {
+    public var enabled: Bool
+    public var autoRamadan: Bool
+    /// Calendar weekday integers (1=Sun, 2=Mon, …, 7=Sat) per Calendar.component(.weekday).
+    public var weeklyDays: Set<Int>
+    public var ayyamAlBeed: Bool
+    public var sixDaysShawwal: Bool
+    public var dayOfArafah: Bool
+    public var firstNineDhulHijjah: Bool
+    public var muharramFast: Bool
+    /// 15 Sha'ban — engine suppresses when !calculationMethod.isShiaMethod.
+    public var midShaban: Bool
+    /// 27 Rajab (Mab'ath) — engine suppresses when !calculationMethod.isShiaMethod.
+    public var mabath: Bool
+    /// Lead time before Fajr for Suhoor notification, in minutes (5–120, step 5).
+    public var suhoorLeadMinutes: Int
+    /// Lead time before Maghrib for Iftar notification, in minutes (5–120, step 5).
+    public var iftarLeadMinutes: Int
+    /// When true, day-before reminder is scheduled.
+    public var dayBeforeEnabled: Bool
+    /// Time of day for day-before reminder. Default 20:00 (8 PM).
+    public var dayBeforeHour: Int
+    public var dayBeforeMinute: Int
+    /// Master switch for all three reminder kinds (Suhoor, Iftar, day-before).
+    public var notificationsEnabled: Bool
+
+    public init(
+        enabled: Bool = false,
+        autoRamadan: Bool = true,
+        weeklyDays: Set<Int> = [],
+        ayyamAlBeed: Bool = false,
+        sixDaysShawwal: Bool = false,
+        dayOfArafah: Bool = false,
+        firstNineDhulHijjah: Bool = false,
+        muharramFast: Bool = false,
+        midShaban: Bool = false,
+        mabath: Bool = false,
+        suhoorLeadMinutes: Int = 30,
+        iftarLeadMinutes: Int = 15,
+        dayBeforeEnabled: Bool = true,
+        dayBeforeHour: Int = 20,
+        dayBeforeMinute: Int = 0,
+        notificationsEnabled: Bool = true
+    ) {
+        self.enabled = enabled
+        self.autoRamadan = autoRamadan
+        self.weeklyDays = weeklyDays
+        self.ayyamAlBeed = ayyamAlBeed
+        self.sixDaysShawwal = sixDaysShawwal
+        self.dayOfArafah = dayOfArafah
+        self.firstNineDhulHijjah = firstNineDhulHijjah
+        self.muharramFast = muharramFast
+        self.midShaban = midShaban
+        self.mabath = mabath
+        self.suhoorLeadMinutes = suhoorLeadMinutes
+        self.iftarLeadMinutes = iftarLeadMinutes
+        self.dayBeforeEnabled = dayBeforeEnabled
+        self.dayBeforeHour = dayBeforeHour
+        self.dayBeforeMinute = dayBeforeMinute
+        self.notificationsEnabled = notificationsEnabled
+    }
+
+    /// Friday in weeklyDays without Thursday or Saturday — discouraged in many traditions.
+    public var hasFridayAloneWarning: Bool {
+        weeklyDays.contains(6) && !weeklyDays.contains(5) && !weeklyDays.contains(7)
+    }
+
+    /// Saturday in weeklyDays without Friday — canonical Sunnah pairing is Fri+Sat.
+    public var hasSaturdayAloneWarning: Bool {
+        weeklyDays.contains(7) && !weeklyDays.contains(6)
+    }
+}

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingMode.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingMode.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Result of evaluating today against the user's Fasting Mode settings.
 /// Pure-data; computed by FastingModeEngine; consumed by every surface.
-public struct FastingDayState: Equatable, Codable, Hashable {
+public struct FastingDayState: Equatable, Codable, Hashable, Sendable {
     /// Is today a fasting day (after prohibition filter)?
     public let isActive: Bool
     /// Why today is active. Nil when isActive == false.
@@ -30,7 +30,7 @@ public struct FastingDayState: Equatable, Codable, Hashable {
     }
 }
 
-public enum FastingTriggerKind: String, Codable, Hashable, CaseIterable {
+public enum FastingTriggerKind: String, Codable, Hashable, CaseIterable, Sendable {
     case autoRamadan
     case weeklySchedule
     case ayyamAlBeed
@@ -42,7 +42,7 @@ public enum FastingTriggerKind: String, Codable, Hashable, CaseIterable {
     case mabath
 }
 
-public enum ProhibitedDay: String, Codable, Hashable, CaseIterable {
+public enum ProhibitedDay: String, Codable, Hashable, CaseIterable, Sendable {
     case eidAlFitr // 1 Shawwal
     case eidAlAdha // 10 Dhul-Hijjah
     case tashriq11 // 11 Dhul-Hijjah
@@ -62,7 +62,7 @@ public enum ProhibitedDay: String, Codable, Hashable, CaseIterable {
 
 /// User-configurable Fasting Mode settings, persisted as a single JSON blob
 /// in UserDefaults under Keys.fastingModeSettings and KVS-synced.
-public struct FastingModeSettings: Codable, Equatable {
+public struct FastingModeSettings: Codable, Equatable, Sendable {
     public var enabled: Bool
     public var autoRamadan: Bool
     /// Calendar weekday integers (1=Sun, 2=Mon, …, 7=Sat) per Calendar.component(.weekday).

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingModeEngine.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingModeEngine.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Pure-functional engine that decides "is today a fasting day?".
+/// Called at every render site; no caching, no I/O.
+public enum FastingModeEngine {
+
+    /// Evaluate today's Fasting Mode state against the user's settings.
+    /// - Parameters:
+    ///   - date: The day to evaluate (typically `Date()`).
+    ///   - settings: User Fasting Mode preferences.
+    ///   - calculationMethod: Affects muharramFast date set and Shia-gated trigger suppression.
+    ///   - hijriCalendar: Calendar(identifier: .islamicUmmAlQura) or similar.
+    ///   - timezone: User's active timezone (settings.activeTimezoneIdentifier).
+    /// - Returns: FastingDayState describing today.
+    public static func evaluate(
+        for date: Date,
+        settings: FastingModeSettings,
+        calculationMethod: CalculationMethod,
+        hijriCalendar: Calendar,
+        timezone: TimeZone
+    ) -> FastingDayState {
+        guard settings.enabled else {
+            return .inactive(date: date)
+        }
+
+        var gregCal = Calendar(identifier: .gregorian)
+        gregCal.timeZone = timezone
+        var hCal = hijriCalendar
+        hCal.timeZone = timezone
+
+        // (Future tasks: prohibition filter runs here before triggers.)
+
+        if settings.autoRamadan {
+            let hijriMonth = hCal.component(.month, from: date)
+            if hijriMonth == 9 {
+                return FastingDayState(
+                    isActive: true,
+                    trigger: .autoRamadan,
+                    prohibition: nil,
+                    date: date
+                )
+            }
+        }
+
+        if !settings.weeklyDays.isEmpty {
+            let weekday = gregCal.component(.weekday, from: date)
+            if settings.weeklyDays.contains(weekday) {
+                return FastingDayState(
+                    isActive: true,
+                    trigger: .weeklySchedule,
+                    prohibition: nil,
+                    date: date
+                )
+            }
+        }
+
+        return .inactive(date: date)
+    }
+}

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingModeEngine.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingModeEngine.swift
@@ -30,27 +30,43 @@ public enum FastingModeEngine {
 
         // (Future tasks: prohibition filter runs here before triggers.)
 
-        if settings.autoRamadan {
-            let hijriMonth = hCal.component(.month, from: date)
-            if hijriMonth == 9 {
-                return FastingDayState(
-                    isActive: true,
-                    trigger: .autoRamadan,
-                    prohibition: nil,
-                    date: date
-                )
-            }
+        let hijriMonth = hCal.component(.month, from: date)
+        let hijriDay = hCal.component(.day, from: date)
+
+        // autoRamadan
+        if settings.autoRamadan, hijriMonth == 9 {
+            return FastingDayState(isActive: true, trigger: .autoRamadan, prohibition: nil, date: date)
         }
 
+        // dayOfArafah — priority over firstNineDhulHijjah on day 9
+        if settings.dayOfArafah, hijriMonth == 12, hijriDay == 9 {
+            return FastingDayState(isActive: true, trigger: .dayOfArafah, prohibition: nil, date: date)
+        }
+
+        // firstNineDhulHijjah
+        if settings.firstNineDhulHijjah, hijriMonth == 12, (1...9).contains(hijriDay) {
+            return FastingDayState(isActive: true, trigger: .firstNineDhulHijjah, prohibition: nil, date: date)
+        }
+
+        // (muharramFast — Task 6)
+
+        // ayyamAlBeed
+        if settings.ayyamAlBeed, (13...15).contains(hijriDay) {
+            return FastingDayState(isActive: true, trigger: .ayyamAlBeed, prohibition: nil, date: date)
+        }
+
+        // sixDaysShawwal
+        if settings.sixDaysShawwal, hijriMonth == 10, (2...7).contains(hijriDay) {
+            return FastingDayState(isActive: true, trigger: .sixDaysShawwal, prohibition: nil, date: date)
+        }
+
+        // (midShaban + mabath — Task 7)
+
+        // weeklySchedule
         if !settings.weeklyDays.isEmpty {
             let weekday = gregCal.component(.weekday, from: date)
             if settings.weeklyDays.contains(weekday) {
-                return FastingDayState(
-                    isActive: true,
-                    trigger: .weeklySchedule,
-                    prohibition: nil,
-                    date: date
-                )
+                return FastingDayState(isActive: true, trigger: .weeklySchedule, prohibition: nil, date: date)
             }
         }
 

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingModeEngine.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingModeEngine.swift
@@ -48,7 +48,17 @@ public enum FastingModeEngine {
             return FastingDayState(isActive: true, trigger: .firstNineDhulHijjah, prohibition: nil, date: date)
         }
 
-        // (muharramFast — Task 6)
+        // muharramFast — date set adapts to calculation method
+        if settings.muharramFast, hijriMonth == 1 {
+            let firesToday: Bool = if calculationMethod.isShiaMethod {
+                hijriDay == 9
+            } else {
+                hijriDay == 9 || hijriDay == 10
+            }
+            if firesToday {
+                return FastingDayState(isActive: true, trigger: .muharramFast, prohibition: nil, date: date)
+            }
+        }
 
         // ayyamAlBeed
         if settings.ayyamAlBeed, (13...15).contains(hijriDay) {

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingModeEngine.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingModeEngine.swift
@@ -28,10 +28,25 @@ public enum FastingModeEngine {
         var hCal = hijriCalendar
         hCal.timeZone = timezone
 
-        // (Future tasks: prohibition filter runs here before triggers.)
-
         let hijriMonth = hCal.component(.month, from: date)
         let hijriDay = hCal.component(.day, from: date)
+
+        // Prohibition filter — always wins over any trigger.
+        if hijriMonth == 10, hijriDay == 1 {
+            return FastingDayState(isActive: false, trigger: nil, prohibition: .eidAlFitr, date: date)
+        }
+        if hijriMonth == 12, hijriDay == 10 {
+            return FastingDayState(isActive: false, trigger: nil, prohibition: .eidAlAdha, date: date)
+        }
+        if hijriMonth == 12, hijriDay == 11 {
+            return FastingDayState(isActive: false, trigger: nil, prohibition: .tashriq11, date: date)
+        }
+        if hijriMonth == 12, hijriDay == 12 {
+            return FastingDayState(isActive: false, trigger: nil, prohibition: .tashriq12, date: date)
+        }
+        if hijriMonth == 12, hijriDay == 13 {
+            return FastingDayState(isActive: false, trigger: nil, prohibition: .tashriq13, date: date)
+        }
 
         // autoRamadan
         if settings.autoRamadan, hijriMonth == 9 {
@@ -70,7 +85,15 @@ public enum FastingModeEngine {
             return FastingDayState(isActive: true, trigger: .sixDaysShawwal, prohibition: nil, date: date)
         }
 
-        // (midShaban + mabath — Task 7)
+        // midShaban — Shia-gated
+        if settings.midShaban, calculationMethod.isShiaMethod, hijriMonth == 8, hijriDay == 15 {
+            return FastingDayState(isActive: true, trigger: .midShaban, prohibition: nil, date: date)
+        }
+
+        // mabath (27 Rajab) — Shia-gated
+        if settings.mabath, calculationMethod.isShiaMethod, hijriMonth == 7, hijriDay == 27 {
+            return FastingDayState(isActive: true, trigger: .mabath, prohibition: nil, date: date)
+        }
 
         // weeklySchedule
         if !settings.weeklyDays.isEmpty {

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/FastingNotificationPlanner.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/FastingNotificationPlanner.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// A planned notification — fire date plus the body text the scheduler should attach.
+public struct FastingNotificationPlan: Equatable, Sendable {
+    public let fireDate: Date
+    public let title: String
+    public let body: String
+    public let identifier: String
+}
+
+/// Pure helpers for computing notification fire dates for Fasting Mode reminders.
+/// Per-platform schedulers wrap these with UNUserNotificationCenter calls.
+public enum FastingNotificationPlanner {
+
+    /// When should the Suhoor reminder fire for a given Fajr time?
+    public static func suhoorFireDate(fajr: Date, settings: FastingModeSettings) -> Date {
+        fajr.addingTimeInterval(-Double(settings.suhoorLeadMinutes) * 60)
+    }
+
+    /// When should the Iftar reminder fire for a given Maghrib time?
+    public static func iftarFireDate(maghrib: Date, settings: FastingModeSettings) -> Date {
+        maghrib.addingTimeInterval(-Double(settings.iftarLeadMinutes) * 60)
+    }
+
+    /// Plan the day-before reminder for `tomorrow`. Returns nil when the reminder should be skipped:
+    /// - dayBeforeEnabled is false
+    /// - notificationsEnabled is false
+    /// - tomorrow has a prohibition
+    /// - tomorrow is Ramadan day 2–30 (day 1 is included; days 2–30 are skipped)
+    /// - tomorrow is inactive (no fasting day to remind about)
+    public static func dayBefore(
+        tomorrow: Date,
+        tomorrowState: FastingDayState,
+        settings: FastingModeSettings,
+        hijriCalendar: Calendar,
+        timezone: TimeZone
+    ) -> FastingNotificationPlan? {
+        guard settings.notificationsEnabled, settings.dayBeforeEnabled else { return nil }
+        guard tomorrowState.prohibition == nil else { return nil }
+        guard tomorrowState.isActive else { return nil }
+
+        var hCal = hijriCalendar
+        hCal.timeZone = timezone
+        let hijriMonth = hCal.component(.month, from: tomorrow)
+        let hijriDay = hCal.component(.day, from: tomorrow)
+        if hijriMonth == 9, hijriDay >= 2, hijriDay <= 30 {
+            return nil
+        }
+
+        var gregCal = Calendar(identifier: .gregorian)
+        gregCal.timeZone = timezone
+        guard let dayBeforeDate = gregCal.date(byAdding: .day, value: -1, to: tomorrow) else { return nil }
+        var components = gregCal.dateComponents([.year, .month, .day], from: dayBeforeDate)
+        components.hour = settings.dayBeforeHour
+        components.minute = settings.dayBeforeMinute
+        guard let fireDate = gregCal.date(from: components) else { return nil }
+
+        let isRamadanDayOne = (hijriMonth == 9 && hijriDay == 1)
+        let title: String
+        let body: String
+        if isRamadanDayOne {
+            title = "🌙 Ramadan begins tomorrow"
+            body = "First Suhoor begins tonight"
+        } else {
+            title = "🕗 Fasting tomorrow"
+            body = "Suhoor preparations begin tonight"
+        }
+
+        let identifier = identifier(for: tomorrow, kind: "daybefore", timezone: timezone)
+        return FastingNotificationPlan(
+            fireDate: fireDate, title: title, body: body, identifier: identifier
+        )
+    }
+
+    /// Stable per-day identifier: `fastingmode.<kind>.yyyy-MM-dd`
+    public static func identifier(for date: Date, kind: String, timezone: TimeZone) -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.timeZone = timezone
+        return "fastingmode.\(kind).\(fmt.string(from: date))"
+    }
+}

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
@@ -78,6 +78,8 @@ public class SettingsManager: ObservableObject {
         static let hilalNotificationEnabled = "hilalNotificationEnabled"
         static let liveActivityEnabled = "liveActivityEnabled"
         static let didShowGPSReDetectPromptV16 = "didShowGPSReDetectPromptV16"
+        static let fastingModeSettings = "fastingModeSettings"
+        static let didShowFastingModePromo = "didShowFastingModePromo"
     }
 
     // MARK: - Keys synced via iCloud KVS
@@ -106,6 +108,7 @@ public class SettingsManager: ObservableObject {
         Keys.selectedCriterion,
         Keys.hilalNotificationEnabled,
         Keys.liveActivityEnabled,
+        Keys.fastingModeSettings,
     ]
 
     @Published public var hasCompletedSetup: Bool {
@@ -286,6 +289,24 @@ public class SettingsManager: ObservableObject {
         }
     }
 
+    /// Fasting Mode user-configurable settings. Persisted as JSON blob; KVS-synced.
+    @Published public var fastingModeSettings: FastingModeSettings {
+        didSet {
+            guard let data = try? JSONEncoder().encode(fastingModeSettings) else { return }
+            defaults.set(data, forKey: Keys.fastingModeSettings)
+            guard !isApplyingRemote else { return }
+            kvs.set(data, forKey: Keys.fastingModeSettings)
+        }
+    }
+
+    /// True once the first-Ramadan Fasting Mode promo banner has been shown.
+    /// NOT KVS-synced — per-device flag.
+    @Published public var didShowFastingModePromo: Bool {
+        didSet {
+            defaults.set(didShowFastingModePromo, forKey: Keys.didShowFastingModePromo)
+        }
+    }
+
     /// True once the v1.6 GPS re-detect prompt has been shown (or dismissed).
     /// Stored in UserDefaults only — NOT KVS-synced; the prompt should fire once per device.
     @Published public var didShowGPSReDetectPromptV16: Bool {
@@ -365,6 +386,14 @@ public class SettingsManager: ObservableObject {
         selectedCriterion = userDefaults.string(forKey: Keys.selectedCriterion) ?? "odeh"
         hilalNotificationEnabled = userDefaults.bool(forKey: Keys.hilalNotificationEnabled)
         liveActivityEnabled = userDefaults.bool(forKey: Keys.liveActivityEnabled)
+
+        if let data = userDefaults.data(forKey: Keys.fastingModeSettings),
+           let decoded = try? JSONDecoder().decode(FastingModeSettings.self, from: data) {
+            fastingModeSettings = decoded
+        } else {
+            fastingModeSettings = FastingModeSettings()
+        }
+        didShowFastingModePromo = userDefaults.bool(forKey: Keys.didShowFastingModePromo)
 
         // Start KVS sync: subscribe to remote changes and trigger an initial pull.
         NotificationCenter.default.addObserver(
@@ -491,6 +520,11 @@ public class SettingsManager: ObservableObject {
             hilalNotificationEnabled = kvs.bool(forKey: key)
         case Keys.liveActivityEnabled:
             liveActivityEnabled = kvs.bool(forKey: key)
+        case Keys.fastingModeSettings:
+            if let data = kvs.data(forKey: key),
+               let decoded = try? JSONDecoder().decode(FastingModeSettings.self, from: data) {
+                fastingModeSettings = decoded
+            }
         default:
             break
         }

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/CalculationMethodJafariTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/CalculationMethodJafariTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import Foundation
+@testable import IqamahCore
+
+@Suite("CalculationMethod Ja'fari + isShiaMethod")
+struct CalculationMethodJafariTests {
+    @Test("jafari case has expected angles")
+    func jafariAngles() {
+        #expect(CalculationMethod.jafari.fajrAngle == 16.0)
+        #expect(CalculationMethod.jafari.ishaAngle == 14.0)
+        #expect(CalculationMethod.jafari.maghribAngle == 4.0)
+    }
+
+    @Test("jafari case identifies as Shia")
+    func jafariIsShia() {
+        #expect(CalculationMethod.jafari.isShiaMethod == true)
+    }
+
+    @Test("tehran case identifies as Shia")
+    func tehranIsShia() {
+        #expect(CalculationMethod.tehran.isShiaMethod == true)
+    }
+
+    @Test("sunni methods are not Shia")
+    func sunniMethodsNotShia() {
+        for method in [CalculationMethod.muslimWorldLeague, .isna, .egypt, .ummAlQura, .karachi] {
+            #expect(method.isShiaMethod == false, "\(method) should not be Shia")
+        }
+    }
+
+    @Test("jafari has displayName and shortName")
+    func jafariNaming() {
+        #expect(!CalculationMethod.jafari.displayName.isEmpty)
+        #expect(!CalculationMethod.jafari.shortName.isEmpty)
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/FastingLabelFormatterTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/FastingLabelFormatterTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import Foundation
+@testable import IqamahCore
+
+@Suite("FastingLabelFormatter")
+struct FastingLabelFormatterTests {
+    static let now = Date(timeIntervalSince1970: 1_745_000_000)
+
+    @Test("inactive state returns original prayer name")
+    func inactivePassthrough() {
+        let state = FastingDayState.inactive(date: Self.now)
+        let result = FastingLabelFormatter.relabel(
+            prayerName: "Fajr",
+            prayerTime: Self.now.addingTimeInterval(60 * 60),
+            currentTime: Self.now,
+            state: state
+        )
+        #expect(result == "Fajr")
+    }
+
+    @Test("active Ramadan within 2h relabels Fajr to Suhoor with moon glyph")
+    func ramadanRelabelFajr() {
+        let state = FastingDayState(
+            isActive: true, trigger: .autoRamadan, prohibition: nil, date: Self.now
+        )
+        let result = FastingLabelFormatter.relabel(
+            prayerName: "Fajr",
+            prayerTime: Self.now.addingTimeInterval(42 * 60),
+            currentTime: Self.now,
+            state: state
+        )
+        #expect(result == "🌙 Suhoor")
+    }
+
+    @Test("active Ramadan within 2h relabels Maghrib to Iftar")
+    func ramadanRelabelMaghrib() {
+        let state = FastingDayState(
+            isActive: true, trigger: .autoRamadan, prohibition: nil, date: Self.now
+        )
+        let result = FastingLabelFormatter.relabel(
+            prayerName: "Maghrib",
+            prayerTime: Self.now.addingTimeInterval(60 * 60),
+            currentTime: Self.now,
+            state: state
+        )
+        #expect(result == "🌙 Iftar")
+    }
+
+    @Test("active Nawafil uses clock glyph instead of moon")
+    func nawafilUsesClockGlyph() {
+        let state = FastingDayState(
+            isActive: true, trigger: .weeklySchedule, prohibition: nil, date: Self.now
+        )
+        let result = FastingLabelFormatter.relabel(
+            prayerName: "Fajr",
+            prayerTime: Self.now.addingTimeInterval(60 * 60),
+            currentTime: Self.now,
+            state: state
+        )
+        #expect(result == "🕗 Suhoor")
+    }
+
+    @Test("outside 2h window returns original prayer name even when active")
+    func outsideWindowPassthrough() {
+        let state = FastingDayState(
+            isActive: true, trigger: .autoRamadan, prohibition: nil, date: Self.now
+        )
+        let result = FastingLabelFormatter.relabel(
+            prayerName: "Fajr",
+            prayerTime: Self.now.addingTimeInterval(3 * 60 * 60),
+            currentTime: Self.now,
+            state: state
+        )
+        #expect(result == "Fajr")
+    }
+
+    @Test("only Fajr and Maghrib are relabeled — other prayers untouched")
+    func otherPrayersUntouched() {
+        let state = FastingDayState(
+            isActive: true, trigger: .autoRamadan, prohibition: nil, date: Self.now
+        )
+        for prayer in ["Sunrise", "Dhuhr", "Asr", "Isha"] {
+            let result = FastingLabelFormatter.relabel(
+                prayerName: prayer,
+                prayerTime: Self.now.addingTimeInterval(60 * 60),
+                currentTime: Self.now,
+                state: state
+            )
+            #expect(result == prayer, "\(prayer) should not be relabeled")
+        }
+    }
+
+    @Test("prohibition state does not relabel")
+    func prohibitionNoRelabel() {
+        let state = FastingDayState(
+            isActive: false, trigger: nil, prohibition: .eidAlFitr, date: Self.now
+        )
+        let result = FastingLabelFormatter.relabel(
+            prayerName: "Fajr",
+            prayerTime: Self.now.addingTimeInterval(60 * 60),
+            currentTime: Self.now,
+            state: state
+        )
+        #expect(result == "Fajr")
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeEngineTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeEngineTests.swift
@@ -326,3 +326,161 @@ struct FastingModeEngineMuharramTests {
         #expect(result.trigger == .muharramFast)
     }
 }
+
+@Suite("FastingModeEngine — Shia-gated triggers")
+struct FastingModeEngineShiaGatedTests {
+    static let hijri = Calendar(identifier: .islamicUmmAlQura)
+    static let tz = TimeZone(identifier: "America/Toronto")!
+
+    static func hijriDate(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        var cal = Calendar(identifier: .islamicUmmAlQura)
+        cal.timeZone = tz
+        return cal.date(from: DateComponents(year: y, month: m, day: d, hour: 12))!
+    }
+
+    @Test("midShaban fires for Shia method on 15 Sha'ban")
+    func midShabanShiaFires() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.midShaban = true
+        let date = Self.hijriDate(1448, 8, 15)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .tehran,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.trigger == .midShaban)
+    }
+
+    @Test("midShaban suppressed for Sunni method even when toggle is true")
+    func midShabanSunniSuppressed() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.midShaban = true
+        let date = Self.hijriDate(1448, 8, 15)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+    }
+
+    @Test("mabath fires for Shia method on 27 Rajab")
+    func mabathShiaFires() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.mabath = true
+        let date = Self.hijriDate(1448, 7, 27)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .jafari,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.trigger == .mabath)
+    }
+
+    @Test("mabath suppressed for Sunni method")
+    func mabathSunniSuppressed() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.mabath = true
+        let date = Self.hijriDate(1448, 7, 27)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .karachi,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+    }
+}
+
+@Suite("FastingModeEngine — prohibition filter")
+struct FastingModeEngineProhibitionTests {
+    static let hijri = Calendar(identifier: .islamicUmmAlQura)
+    static let tz = TimeZone(identifier: "America/Toronto")!
+
+    static func hijriDate(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        var cal = Calendar(identifier: .islamicUmmAlQura)
+        cal.timeZone = tz
+        return cal.date(from: DateComponents(year: y, month: m, day: d, hour: 12))!
+    }
+
+    @Test("Eid al-Fitr suppresses sixDaysShawwal trigger")
+    func eidAlFitrSuppressesShawwal() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.sixDaysShawwal = true
+        let date = Self.hijriDate(1448, 10, 1)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+        #expect(result.prohibition == .eidAlFitr)
+    }
+
+    @Test("Eid al-Adha suppresses any trigger")
+    func eidAlAdhaSuppresses() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.dayOfArafah = true
+        s.firstNineDhulHijjah = true
+        s.weeklyDays = [1, 2, 3, 4, 5, 6, 7]
+        let date = Self.hijriDate(1448, 12, 10)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+        #expect(result.prohibition == .eidAlAdha)
+    }
+
+    @Test("Tashriq 11 suppresses ayyamAlBeed")
+    func tashriq11SuppressesAyyamAlBeed() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.ayyamAlBeed = true
+        let date = Self.hijriDate(1448, 12, 11)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.prohibition == .tashriq11)
+    }
+
+    @Test("Tashriq 12 suppresses any trigger")
+    func tashriq12Suppresses() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.weeklyDays = [1, 2, 3, 4, 5, 6, 7]
+        let date = Self.hijriDate(1448, 12, 12)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.prohibition == .tashriq12)
+    }
+
+    @Test("Tashriq 13 suppresses ayyamAlBeed")
+    func tashriq13SuppressesAyyamAlBeed() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.ayyamAlBeed = true
+        let date = Self.hijriDate(1448, 12, 13)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.prohibition == .tashriq13)
+    }
+
+    @Test("ordinary day with no triggers stays inactive (no prohibition)")
+    func ordinaryDayInactive() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        let date = Self.hijriDate(1448, 6, 20)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+        #expect(result.prohibition == nil)
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeEngineTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeEngineTests.swift
@@ -232,3 +232,97 @@ struct FastingModeEngineHijriTests {
         #expect(result.trigger == .dayOfArafah)
     }
 }
+
+@Suite("FastingModeEngine — muharramFast tradition-adaptive")
+struct FastingModeEngineMuharramTests {
+    static let hijri = Calendar(identifier: .islamicUmmAlQura)
+    static let tz = TimeZone(identifier: "America/Toronto")!
+
+    static func hijriDate(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        var cal = Calendar(identifier: .islamicUmmAlQura)
+        cal.timeZone = tz
+        return cal.date(from: DateComponents(year: y, month: m, day: d, hour: 12))!
+    }
+
+    @Test("Sunni method: muharramFast fires on 10 Muharram (Ashura)")
+    func sunniDay10() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.muharramFast = true
+        let date = Self.hijriDate(1448, 1, 10)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == true)
+        #expect(result.trigger == .muharramFast)
+    }
+
+    @Test("Sunni method: muharramFast fires on 9 Muharram (Tasu'a)")
+    func sunniDay9() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.muharramFast = true
+        let date = Self.hijriDate(1448, 1, 9)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .isna,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == true)
+        #expect(result.trigger == .muharramFast)
+    }
+
+    @Test("Sunni method: muharramFast does NOT fire on 11 Muharram")
+    func sunniDay11Inactive() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.muharramFast = true
+        let date = Self.hijriDate(1448, 1, 11)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+    }
+
+    @Test("Shia (tehran): muharramFast fires on 9 Muharram only")
+    func shiaTehranDay9() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.muharramFast = true
+        let date = Self.hijriDate(1448, 1, 9)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .tehran,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == true)
+        #expect(result.trigger == .muharramFast)
+    }
+
+    @Test("Shia (tehran): muharramFast does NOT fire on 10 Muharram")
+    func shiaTehranDay10Inactive() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.muharramFast = true
+        let date = Self.hijriDate(1448, 1, 10)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .tehran,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+    }
+
+    @Test("Shia (jafari): muharramFast fires on 9 Muharram")
+    func shiaJafariDay9() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.muharramFast = true
+        let date = Self.hijriDate(1448, 1, 9)
+        let result = FastingModeEngine.evaluate(
+            for: date, settings: s, calculationMethod: .jafari,
+            hijriCalendar: Self.hijri, timezone: Self.tz
+        )
+        #expect(result.isActive == true)
+        #expect(result.trigger == .muharramFast)
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeEngineTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeEngineTests.swift
@@ -127,3 +127,108 @@ struct FastingModeEngineBaseTests {
         #expect(a == b)
     }
 }
+
+@Suite("FastingModeEngine — Hijri-date triggers")
+struct FastingModeEngineHijriTests {
+    static let hijri = Calendar(identifier: .islamicUmmAlQura)
+    static let tz = TimeZone(identifier: "America/Toronto")!
+
+    /// Build a Date for the given Hijri Y/M/D in the test timezone, at noon.
+    static func hijriDate(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        var cal = Calendar(identifier: .islamicUmmAlQura)
+        cal.timeZone = tz
+        return cal.date(from: DateComponents(year: y, month: m, day: d, hour: 12))!
+    }
+
+    @Test("ayyamAlBeed fires on day 13 of any Hijri month")
+    func ayyamAlBeed13() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.ayyamAlBeed = true
+        let date = Self.hijriDate(1448, 8, 13)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.isActive == true)
+        #expect(result.trigger == .ayyamAlBeed)
+    }
+
+    @Test("ayyamAlBeed fires on day 14")
+    func ayyamAlBeed14() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.ayyamAlBeed = true
+        let date = Self.hijriDate(1448, 8, 14)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.trigger == .ayyamAlBeed)
+    }
+
+    @Test("ayyamAlBeed does not fire on day 16")
+    func ayyamAlBeedDay16() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.ayyamAlBeed = true
+        let date = Self.hijriDate(1448, 8, 16)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.isActive == false)
+    }
+
+    @Test("sixDaysShawwal fires on day 2 Shawwal")
+    func sixShawwalDay2() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.sixDaysShawwal = true
+        let date = Self.hijriDate(1448, 10, 2)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.trigger == .sixDaysShawwal)
+    }
+
+    @Test("sixDaysShawwal fires on day 7 Shawwal")
+    func sixShawwalDay7() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.sixDaysShawwal = true
+        let date = Self.hijriDate(1448, 10, 7)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.trigger == .sixDaysShawwal)
+    }
+
+    @Test("sixDaysShawwal does not fire on day 8 Shawwal")
+    func sixShawwalDay8Inactive() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.sixDaysShawwal = true
+        let date = Self.hijriDate(1448, 10, 8)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.isActive == false)
+    }
+
+    @Test("dayOfArafah fires on 9 Dhul-Hijjah")
+    func arafahFires() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.dayOfArafah = true
+        let date = Self.hijriDate(1448, 12, 9)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.trigger == .dayOfArafah)
+    }
+
+    @Test("firstNineDhulHijjah fires on day 5")
+    func firstNineDay5() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.firstNineDhulHijjah = true
+        let date = Self.hijriDate(1448, 12, 5)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.trigger == .firstNineDhulHijjah)
+    }
+
+    @Test("on 9 Dhul-Hijjah, dayOfArafah wins over firstNineDhulHijjah")
+    func arafahPriorityOverFirstNine() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.dayOfArafah = true
+        s.firstNineDhulHijjah = true
+        let date = Self.hijriDate(1448, 12, 9)
+        let result = FastingModeEngine.evaluate(for: date, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(result.trigger == .dayOfArafah)
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeEngineTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeEngineTests.swift
@@ -1,0 +1,129 @@
+import Testing
+import Foundation
+@testable import IqamahCore
+
+@Suite("FastingModeEngine — base triggers")
+struct FastingModeEngineBaseTests {
+    /// Convenience: build a Date at given Gregorian Y/M/D in a known timezone.
+    static func date(_ y: Int, _ m: Int, _ d: Int, tz: TimeZone = TimeZone(identifier: "America/Toronto")!) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+        return cal.date(from: DateComponents(year: y, month: m, day: d, hour: 12))!
+    }
+
+    static let hijri = Calendar(identifier: .islamicUmmAlQura)
+    static let tz = TimeZone(identifier: "America/Toronto")!
+
+    @Test("engine is inactive when settings.enabled is false")
+    func disabledReturnsInactive() {
+        var s = FastingModeSettings()
+        s.enabled = false
+        s.autoRamadan = true
+        let result = FastingModeEngine.evaluate(
+            for: Self.date(2026, 2, 17),
+            settings: s,
+            calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+        #expect(result.trigger == nil)
+    }
+
+    @Test("autoRamadan fires on a Ramadan day")
+    func autoRamadanFires() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.autoRamadan = true
+        // 2026-03-01 (Toronto) resolves to Hijri 1447-9-12 under islamicUmmAlQura — i.e. Ramadan.
+        let ramadanDay = Self.date(2026, 3, 1)
+        // Guard against calendar-data drift — fails loud if the date assumption breaks.
+        #expect(Self.hijri.component(.month, from: ramadanDay) == 9)
+        let result = FastingModeEngine.evaluate(
+            for: ramadanDay,
+            settings: s,
+            calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(result.isActive == true)
+        #expect(result.trigger == .autoRamadan)
+    }
+
+    @Test("autoRamadan does not fire outside Ramadan")
+    func autoRamadanInactiveOutsideRamadan() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.autoRamadan = true
+        // 2026-07-15 (Toronto) resolves to Hijri 1448-2-1 under islamicUmmAlQura — clearly not Ramadan.
+        let nonRamadanDay = Self.date(2026, 7, 15)
+        // Guard against calendar-data drift — fails loud if the date assumption breaks.
+        #expect(Self.hijri.component(.month, from: nonRamadanDay) != 9)
+        let result = FastingModeEngine.evaluate(
+            for: nonRamadanDay,
+            settings: s,
+            calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(result.trigger != .autoRamadan)
+        #expect(result.isActive == false)
+    }
+
+    @Test("autoRamadan does not fire when toggle is off")
+    func autoRamadanOff() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.autoRamadan = false
+        let result = FastingModeEngine.evaluate(
+            for: Self.date(2026, 3, 1),
+            settings: s,
+            calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(result.trigger != .autoRamadan)
+    }
+
+    @Test("weeklySchedule fires on a Monday")
+    func weeklyMondayFires() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.weeklyDays = [2]
+        let result = FastingModeEngine.evaluate(
+            for: Self.date(2026, 9, 14),
+            settings: s,
+            calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(result.isActive == true)
+        #expect(result.trigger == .weeklySchedule)
+    }
+
+    @Test("weeklySchedule does not fire on a Wednesday when only Mon/Thu set")
+    func weeklyWednesdayInactive() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.weeklyDays = [2, 5]
+        let result = FastingModeEngine.evaluate(
+            for: Self.date(2026, 9, 16),
+            settings: s,
+            calculationMethod: .muslimWorldLeague,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(result.isActive == false)
+    }
+
+    @Test("engine is pure — same input yields same output")
+    func enginePurity() {
+        var s = FastingModeSettings()
+        s.enabled = true
+        s.weeklyDays = [2]
+        let input = Self.date(2026, 9, 14)
+        let a = FastingModeEngine.evaluate(for: input, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        let b = FastingModeEngine.evaluate(for: input, settings: s, calculationMethod: .muslimWorldLeague, hijriCalendar: Self.hijri, timezone: Self.tz)
+        #expect(a == b)
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeSettingsCodecTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeSettingsCodecTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+@testable import IqamahCore
+
+@Suite("FastingModeSettings Codec")
+struct FastingModeSettingsCodecTests {
+    @Test("default settings round-trip preserves all fields")
+    func defaultRoundTrip() throws {
+        let original = FastingModeSettings()
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(FastingModeSettings.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("populated settings round-trip preserves all fields")
+    func populatedRoundTrip() throws {
+        var original = FastingModeSettings()
+        original.enabled = true
+        original.weeklyDays = [2, 5]    // Mon, Thu
+        original.midShaban = true
+        original.suhoorLeadMinutes = 60
+        original.iftarLeadMinutes = 20
+        original.dayBeforeHour = 21
+        original.dayBeforeMinute = 30
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(FastingModeSettings.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("legacy JSON missing new fields decodes with defaults")
+    func forwardCompatDecode() throws {
+        // Simulates a v1.6 install whose persisted JSON only had the original fields,
+        // before midShaban/mabath/dayBeforeMinute were added. Decoding must fall back
+        // to struct defaults for the absent fields.
+        let legacyJSON = """
+        {
+            "enabled": true,
+            "autoRamadan": true,
+            "weeklyDays": [2, 5],
+            "ayyamAlBeed": false,
+            "sixDaysShawwal": false,
+            "dayOfArafah": false,
+            "firstNineDhulHijjah": false,
+            "muharramFast": false,
+            "suhoorLeadMinutes": 30,
+            "iftarLeadMinutes": 15,
+            "dayBeforeEnabled": true,
+            "dayBeforeHour": 20,
+            "notificationsEnabled": true
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(FastingModeSettings.self, from: legacyJSON)
+        #expect(decoded.enabled == true)
+        #expect(decoded.weeklyDays == [2, 5])
+        #expect(decoded.midShaban == false)       // defaulted (absent in JSON)
+        #expect(decoded.mabath == false)          // defaulted (absent in JSON)
+        #expect(decoded.dayBeforeMinute == 0)     // defaulted (absent in JSON)
+    }
+
+    @Test("Friday-alone warning triggers when only Fri")
+    func fridayAloneAlone() {
+        var s = FastingModeSettings()
+        s.weeklyDays = [6]
+        #expect(s.hasFridayAloneWarning == true)
+    }
+
+    @Test("Friday-alone warning clears when paired with Thursday")
+    func fridayWithThursdayClears() {
+        var s = FastingModeSettings()
+        s.weeklyDays = [5, 6]
+        #expect(s.hasFridayAloneWarning == false)
+    }
+
+    @Test("Friday-alone warning clears when paired with Saturday")
+    func fridayWithSaturdayClears() {
+        var s = FastingModeSettings()
+        s.weeklyDays = [6, 7]
+        #expect(s.hasFridayAloneWarning == false)
+    }
+
+    @Test("Saturday-alone warning triggers when only Sat")
+    func saturdayAlone() {
+        var s = FastingModeSettings()
+        s.weeklyDays = [7]
+        #expect(s.hasSaturdayAloneWarning == true)
+    }
+
+    @Test("Saturday-alone warning clears when paired with Friday")
+    func saturdayWithFridayClears() {
+        var s = FastingModeSettings()
+        s.weeklyDays = [6, 7]
+        #expect(s.hasSaturdayAloneWarning == false)
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeTypesTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/FastingModeTypesTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Foundation
+@testable import IqamahCore
+
+@Suite("FastingModeSettings + FastingDayState")
+struct FastingModeTypesTests {
+    @Test("FastingModeSettings has expected defaults")
+    func fastingModeSettingsDefaults() {
+        let settings = FastingModeSettings()
+        #expect(!settings.enabled)
+        #expect(settings.autoRamadan)
+        #expect(settings.weeklyDays == [])
+        #expect(!settings.ayyamAlBeed)
+        #expect(!settings.sixDaysShawwal)
+        #expect(!settings.dayOfArafah)
+        #expect(!settings.firstNineDhulHijjah)
+        #expect(!settings.muharramFast)
+        #expect(!settings.midShaban)
+        #expect(!settings.mabath)
+        #expect(settings.suhoorLeadMinutes == 30)
+        #expect(settings.iftarLeadMinutes == 15)
+        #expect(settings.dayBeforeEnabled)
+        #expect(settings.dayBeforeHour == 20)
+        #expect(settings.dayBeforeMinute == 0)
+        #expect(settings.notificationsEnabled)
+    }
+
+    @Test("Friday-alone weekly selection triggers warning")
+    func fridayAloneWarning() {
+        var settings = FastingModeSettings()
+        settings.weeklyDays = [6]
+        #expect(settings.hasFridayAloneWarning)
+
+        settings.weeklyDays = [5, 6]
+        #expect(!settings.hasFridayAloneWarning)
+
+        settings.weeklyDays = [6, 7]
+        #expect(!settings.hasFridayAloneWarning)
+    }
+
+    @Test("Saturday-alone weekly selection triggers warning")
+    func saturdayAloneWarning() {
+        var settings = FastingModeSettings()
+        settings.weeklyDays = [7]
+        #expect(settings.hasSaturdayAloneWarning)
+
+        settings.weeklyDays = [6, 7]
+        #expect(!settings.hasSaturdayAloneWarning)
+    }
+
+    @Test("FastingModeSettings round-trips through Codable")
+    func codableRoundTrip() throws {
+        let original = FastingModeSettings(
+            enabled: true,
+            autoRamadan: false,
+            weeklyDays: [2, 5],
+            ayyamAlBeed: true,
+            sixDaysShawwal: true,
+            dayOfArafah: true,
+            firstNineDhulHijjah: true,
+            muharramFast: true,
+            midShaban: true,
+            mabath: true,
+            suhoorLeadMinutes: 45,
+            iftarLeadMinutes: 20,
+            dayBeforeEnabled: false,
+            dayBeforeHour: 19,
+            dayBeforeMinute: 30,
+            notificationsEnabled: false
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(FastingModeSettings.self, from: data)
+        #expect(original == decoded)
+    }
+
+    @Test("FastingDayState.inactive convenience produces an inactive state")
+    func inactiveConvenience() {
+        let date = Date()
+        let state = FastingDayState.inactive(date: date)
+        #expect(!state.isActive)
+        #expect(state.trigger == nil)
+        #expect(state.prohibition == nil)
+        #expect(state.date == date)
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/FastingNotificationPlannerTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/FastingNotificationPlannerTests.swift
@@ -1,0 +1,149 @@
+import Testing
+import Foundation
+@testable import IqamahCore
+
+@Suite("FastingNotificationPlanner")
+struct FastingNotificationPlannerTests {
+    static let tz = TimeZone(identifier: "America/Toronto")!
+    static let hijri = Calendar(identifier: .islamicUmmAlQura)
+
+    static func fajrTime(hour: Int = 5, minute: Int = 12) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+        return cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: hour, minute: minute))!
+    }
+
+    static func maghribTime(hour: Int = 20, minute: Int = 32) -> Date {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+        return cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: hour, minute: minute))!
+    }
+
+    @Test("Suhoor 30-min lead fires 30 minutes before Fajr")
+    func suhoorThirtyMinLead() {
+        var s = FastingModeSettings()
+        s.suhoorLeadMinutes = 30
+        let fajr = Self.fajrTime()
+        let fire = FastingNotificationPlanner.suhoorFireDate(fajr: fajr, settings: s)
+        #expect(fire == fajr.addingTimeInterval(-30 * 60))
+    }
+
+    @Test("Suhoor 120-min lead fires 2 hours before Fajr")
+    func suhoorOneTwentyMinLead() {
+        var s = FastingModeSettings()
+        s.suhoorLeadMinutes = 120
+        let fajr = Self.fajrTime()
+        let fire = FastingNotificationPlanner.suhoorFireDate(fajr: fajr, settings: s)
+        #expect(fire == fajr.addingTimeInterval(-120 * 60))
+    }
+
+    @Test("Iftar 15-min lead fires 15 minutes before Maghrib")
+    func iftarFifteenMinLead() {
+        var s = FastingModeSettings()
+        s.iftarLeadMinutes = 15
+        let maghrib = Self.maghribTime()
+        let fire = FastingNotificationPlanner.iftarFireDate(maghrib: maghrib, settings: s)
+        #expect(fire == maghrib.addingTimeInterval(-15 * 60))
+    }
+
+    @Test("Day-before fires for Ramadan day 1 — tomorrow is 1 Ramadan")
+    func dayBeforeRamadanDay1Fires() {
+        var s = FastingModeSettings()
+        s.dayBeforeEnabled = true
+        s.dayBeforeHour = 20
+        s.dayBeforeMinute = 0
+        s.autoRamadan = true
+        var hCal = Self.hijri
+        hCal.timeZone = Self.tz
+        let tomorrow = hCal.date(from: DateComponents(year: 1448, month: 9, day: 1, hour: 12))!
+        let plan = FastingNotificationPlanner.dayBefore(
+            tomorrow: tomorrow,
+            tomorrowState: FastingDayState(isActive: true, trigger: .autoRamadan, prohibition: nil, date: tomorrow),
+            settings: s,
+            hijriCalendar: hCal,
+            timezone: Self.tz
+        )
+        #expect(plan != nil)
+    }
+
+    @Test("Day-before skipped for Ramadan day 2")
+    func dayBeforeRamadanDay2Skipped() {
+        var s = FastingModeSettings()
+        s.dayBeforeEnabled = true
+        s.autoRamadan = true
+        var hCal = Self.hijri
+        hCal.timeZone = Self.tz
+        let tomorrow = hCal.date(from: DateComponents(year: 1448, month: 9, day: 2, hour: 12))!
+        let plan = FastingNotificationPlanner.dayBefore(
+            tomorrow: tomorrow,
+            tomorrowState: FastingDayState(isActive: true, trigger: .autoRamadan, prohibition: nil, date: tomorrow),
+            settings: s,
+            hijriCalendar: hCal,
+            timezone: Self.tz
+        )
+        #expect(plan == nil)
+    }
+
+    @Test("Day-before fires for an active non-Ramadan day")
+    func dayBeforeActiveNonRamadanFires() {
+        var s = FastingModeSettings()
+        s.dayBeforeEnabled = true
+        var hCal = Self.hijri
+        hCal.timeZone = Self.tz
+        let tomorrow = hCal.date(from: DateComponents(year: 1448, month: 6, day: 15, hour: 12))!
+        let plan = FastingNotificationPlanner.dayBefore(
+            tomorrow: tomorrow,
+            tomorrowState: FastingDayState(isActive: true, trigger: .weeklySchedule, prohibition: nil, date: tomorrow),
+            settings: s,
+            hijriCalendar: hCal,
+            timezone: Self.tz
+        )
+        #expect(plan != nil)
+    }
+
+    @Test("Day-before skipped when dayBeforeEnabled is false")
+    func dayBeforeDisabledSkipped() {
+        var s = FastingModeSettings()
+        s.dayBeforeEnabled = false
+        let tomorrow = Self.fajrTime()
+        let plan = FastingNotificationPlanner.dayBefore(
+            tomorrow: tomorrow,
+            tomorrowState: FastingDayState(isActive: true, trigger: .weeklySchedule, prohibition: nil, date: tomorrow),
+            settings: s,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(plan == nil)
+    }
+
+    @Test("Day-before skipped when tomorrow is hard-prohibited")
+    func dayBeforeProhibitionSkipped() {
+        var s = FastingModeSettings()
+        s.dayBeforeEnabled = true
+        let tomorrow = Self.fajrTime()
+        let plan = FastingNotificationPlanner.dayBefore(
+            tomorrow: tomorrow,
+            tomorrowState: FastingDayState(isActive: false, trigger: nil, prohibition: .eidAlFitr, date: tomorrow),
+            settings: s,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(plan == nil)
+    }
+
+    @Test("Day-before skipped when notificationsEnabled is false")
+    func dayBeforeNotificationsDisabledSkipped() {
+        var s = FastingModeSettings()
+        s.notificationsEnabled = false
+        s.dayBeforeEnabled = true
+        let tomorrow = Self.fajrTime()
+        let plan = FastingNotificationPlanner.dayBefore(
+            tomorrow: tomorrow,
+            tomorrowState: FastingDayState(isActive: true, trigger: .weeklySchedule, prohibition: nil, date: tomorrow),
+            settings: s,
+            hijriCalendar: Self.hijri,
+            timezone: Self.tz
+        )
+        #expect(plan == nil)
+    }
+}

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/IqamahModelTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/IqamahModelTests.swift
@@ -8,9 +8,9 @@ import CoreLocation
 @Suite("Calculation Method Model Tests")
 struct CalculationMethodTests {
 
-    @Test("All 6 calculation methods are available")
+    @Test("All 7 calculation methods are available")
     func allMethodsPresent() {
-        #expect(CalculationMethod.allCases.count == 6)
+        #expect(CalculationMethod.allCases.count == 7)
     }
 
     @Test("Each method has a non-empty display name", arguments: CalculationMethod.allCases)
@@ -47,10 +47,11 @@ struct CalculationMethodTests {
         }
     }
 
-    @Test("Tehran method has a Maghrib angle; others do not")
+    @Test("Tehran and Ja'fari methods have a Maghrib angle; others do not")
     func maghribAngle() {
         #expect(CalculationMethod.tehran.maghribAngle == 4.5)
-        for method in CalculationMethod.allCases where method != .tehran {
+        #expect(CalculationMethod.jafari.maghribAngle == 4.0)
+        for method in CalculationMethod.allCases where method != .tehran && method != .jafari {
             #expect(method.maghribAngle == nil, "\(method.displayName) should not have Maghrib angle")
         }
     }

--- a/docs/superpowers/plans/2026-05-21-fasting-mode.md
+++ b/docs/superpowers/plans/2026-05-21-fasting-mode.md
@@ -94,6 +94,50 @@ Continued in task sections below.
 
 ---
 
+## Implementation Progress
+
+> Updated 2026-05-22. Next session: resume from Task 3. Worktree
+> `~/Projects/iqamah/iqamah/.claude/worktrees/fasting-mode-foundation`
+> on branch `feature/fasting-mode-foundation` (pushed).
+
+| # | Task | Status | Commit |
+|---|---|---|---|
+| — | Bump to v1.6.0 build 1 | ✅ Done | `4d1c7c7` |
+| 1 | `.jafari` + `isShiaMethod` | ✅ Done | `c4f9164` |
+| 2 | Fasting Mode value types | ✅ Done | `012456d` |
+| 3 | `FastingModeSettings` JSON codec + SettingsManager | 🟡 Pending | — |
+| 4 | Engine — autoRamadan + weeklySchedule | 🟡 Pending | — |
+| 5 | Engine — Hijri-date triggers (4) | 🟡 Pending | — |
+| 6 | Engine — muharramFast | 🟡 Pending | — |
+| 7 | Engine — Shia-gated + prohibition filter | 🟡 Pending | — |
+| 8 | `FastingLabelFormatter` | 🟡 Pending | — |
+| 9 | `FastingNotificationPlanner` | 🟡 Pending | — |
+| 10–21 | UI + notifications + docs + final | 🟡 Pending (PR-2 / PR-3) | — |
+
+**Test count delta so far:** 185 → 195 (+10), all Swift Testing.
+
+**Hand-off notes for the next session:**
+
+1. **Branch base:** This branch was cut from `origin/main` at `5791936`,
+   before PR #131 merged. When #131 lands on main, rebase this branch
+   and bump the newly-added IqamahWatch target `MARKETING_VERSION` /
+   `CURRENT_PROJECT_VERSION` from 1.5.0/14 to 1.6.0/1 as part of the
+   rebase commit.
+2. **Test framework:** Project standard is Swift Testing
+   (`@Suite` / `@Test` / `#expect`). Task 2's implementer initially
+   wrote XCTest and had to migrate. Tell each new implementer up front.
+3. **CI gates per commit:** `swiftlint --strict iqamah/` clean,
+   `swiftformat --lint iqamah/` clean, `cd Packages/IqamahCore && swift test`
+   green, Conventional Commits + `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer.
+4. **PR-1 scope:** Open after Task 9. Title:
+   `feat(core): Fasting Mode foundation (Tasks 1–9 of EPIC-0017)`.
+5. **Docs promotion (Task 20) waits for PR-3** — do not touch
+   `docs/ENHANCEMENTS.md` / `docs/RELEASE_PLAN.md` / `docs/TEST_CASES.md` /
+   `docs/ID_REGISTRY.md` until then; the IDs allocated in this plan's
+   header should still be considered reserved.
+
+---
+
 ## Task 1: Add `.jafari` calculation method + `isShiaMethod` helper + picker entry
 
 **Files:**

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -1538,7 +1538,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
@@ -1555,7 +1555,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1575,7 +1575,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
@@ -1592,7 +1592,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1642,11 +1642,11 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahLiveActivity/IqamahLiveActivity.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahLiveActivity/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.liveactivity;
 				PRODUCT_NAME = IqamahLiveActivity;
 				SDKROOT = iphoneos;
@@ -1660,11 +1660,11 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahLiveActivity/IqamahLiveActivity.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahLiveActivity/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.liveactivity;
 				PRODUCT_NAME = IqamahLiveActivity;
 				SDKROOT = iphoneos;
@@ -1678,7 +1678,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidgetMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/InfoMac.plist;
@@ -1688,7 +1688,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fablesoft.iqamah.mac-widget";
 				PRODUCT_NAME = IqamahWidgetMac;
 				SDKROOT = macosx;
@@ -1704,7 +1704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidgetMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/InfoMac.plist;
@@ -1714,7 +1714,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fablesoft.iqamah.mac-widget";
 				PRODUCT_NAME = IqamahWidgetMac;
 				SDKROOT = macosx;
@@ -1769,7 +1769,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/Info.plist;
@@ -1779,7 +1779,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.widget;
 				PRODUCT_NAME = IqamahWidget;
 				SDKROOT = iphoneos;
@@ -1796,7 +1796,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/Info.plist;
@@ -1806,7 +1806,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.widget;
 				PRODUCT_NAME = IqamahWidget;
 				SDKROOT = iphoneos;
@@ -1886,7 +1886,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "iqamah/iOS/iqamah-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
@@ -1898,7 +1898,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1916,7 +1916,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "iqamah/iOS/iqamah-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
@@ -1928,7 +1928,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -1538,7 +1538,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
@@ -1575,7 +1575,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
@@ -1642,7 +1642,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahLiveActivity/IqamahLiveActivity.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahLiveActivity/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -1660,7 +1660,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahLiveActivity/IqamahLiveActivity.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahLiveActivity/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -1678,7 +1678,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidgetMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/InfoMac.plist;
@@ -1704,7 +1704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidgetMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/InfoMac.plist;
@@ -1769,7 +1769,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/Info.plist;
@@ -1796,7 +1796,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWidget/IqamahWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = IqamahWidget/Info.plist;
@@ -1886,7 +1886,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "iqamah/iOS/iqamah-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
@@ -1916,7 +1916,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "iqamah/iOS/iqamah-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -1734,8 +1734,10 @@
 				ASYNCTESTTIMEOUT = 60;
 				CODE_SIGN_ENTITLEMENTS = IqamahWatch/IqamahWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahWatch/Info.plist;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.watch;
 				PRODUCT_NAME = IqamahWatch;
 				SDKROOT = watchos;
@@ -1753,8 +1755,10 @@
 				ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT = YES;
 				CODE_SIGN_ENTITLEMENTS = IqamahWatch/IqamahWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahWatch/Info.plist;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.watch;
 				PRODUCT_NAME = IqamahWatch;
 				SDKROOT = watchos;
@@ -1852,8 +1856,10 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWatchWidget/IqamahWatchWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahWatchWidget/Info.plist;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.watch.widget;
 				PRODUCT_NAME = IqamahWatchWidget;
 				SDKROOT = watchos;
@@ -1868,8 +1874,10 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = IqamahWatchWidget/IqamahWatchWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 96Y29SP9JR;
 				INFOPLIST_FILE = IqamahWatchWidget/Info.plist;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fablesoft.iqamah.watch.widget;
 				PRODUCT_NAME = IqamahWatchWidget;
 				SDKROOT = watchos;

--- a/iqamah/iOS/Info.plist
+++ b/iqamah/iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>1</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Iqamah uses your location to calculate accurate prayer times for your area.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
## Summary

Foundation slice of EPIC-0017 (Fasting Mode, ENH-002). Pure-Swift logic in `Packages/IqamahCore` — no SwiftUI, no UNUserNotificationCenter, no platform code. Subsequent PRs (Tasks 10–21) wire surfaces (banner, menu bar, iOS hero card, watchOS tab, widgets, Live Activity, settings UI, per-platform schedulers).

- **`CalculationMethod.jafari`** + `isShiaMethod` helper (Task 1)
- **Value types** in `FastingMode.swift`: `FastingDayState`, `FastingTriggerKind` (9 cases), `ProhibitedDay` (5 cases), `FastingModeSettings` (16 fields, custom `init(from:)` for forward-compat decode) — all `Sendable` (Task 2)
- **`SettingsManager` wiring**: `fastingModeSettings` (KVS-synced JSON blob) + `didShowFastingModePromo` (device-local) (Task 3)
- **`FastingModeEngine`** — pure `(date, settings, method, hijriCalendar, timezone) → FastingDayState`. 9 triggers + 5 prohibitions. Prohibition filter wins; Shia-gated triggers (`midShaban`, `mabath`) suppressed when method isn't Shia; `muharramFast` date set adapts (Sunni: 9+10 Muharram, Shia: 9 only). Trigger priority: prohibitions → `autoRamadan` → `dayOfArafah` → `firstNineDhulHijjah` → `muharramFast` → `ayyamAlBeed` → `sixDaysShawwal` → `midShaban` → `mabath` → `weeklySchedule` (Tasks 4–7)
- **`FastingLabelFormatter`** — relabels Fajr→Suhoor, Maghrib→Iftar within 2h window; 🌙 for `.autoRamadan`, 🕗 for any other trigger; passes through on inactive/prohibition/outside-window/other-prayer cases (Task 8)
- **`FastingNotificationPlanner`** — pure fire-date helpers for Suhoor/Iftar/day-before. `dayBefore` returns nil when reminders should be skipped (toggle off, prohibition, Ramadan days 2–30, inactive tomorrow). Stable per-day identifiers `fastingmode.<kind>.yyyy-MM-dd` for cancellation/replacement (Task 9)
- **CFBundleVersion** bumped 1 → 15 across all extension targets (the branch-base bump commit had reset it to 1; fixed pre-PR to satisfy TestFlight monotonic-increment)

**Tests:** 251 passing in IqamahCore (was 195 at branch base; +56 new across 9 suites).

**Acceptance criteria covered:** AC-0357, AC-0358, AC-0359, AC-0360, AC-0361, AC-0362, AC-0363, AC-0364, AC-0365, AC-0376 (logic), AC-0377 (logic).

**Known follow-ups (out of scope for this PR):**
- Watch target on this branch still lacks `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` keys — needs the PR #131 rebase before merging.
- All public body strings in the planner are English; localization comes in the wiring PRs.
- `FastingLabelFormatter.relabel` matches prayer names by raw string — fine for v1; an enum-keyed overload may land alongside the consumer tasks.

## Test plan

- [x] `cd Packages/IqamahCore && swift test` → 251/251 pass
- [x] `cd Packages/IqamahCore && swift build` → clean (only pre-existing unrelated warning in `HilalGridRequest.swift`)
- [ ] After PR #131 lands, rebase and add `MARKETING_VERSION = 1.6.0` / `CURRENT_PROJECT_VERSION = 15` to the watch target in the rebase commit
- [ ] Full multi-platform Xcode build (iOS, iPad, watchOS, macOS) — verified by CI on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)