### PR TITLE
fix(v1.6.0): LA rollover, Start-on-Login errors, macOS toolbar polish, ENH-025

### DIFF
--- a/docs/ENHANCEMENTS.md
+++ b/docs/ENHANCEMENTS.md
@@ -391,6 +391,28 @@ The audit showed Iqamah is doing everything correctly within Apple's default con
 
 ---
 
+### ENH-025 — Per-day Alert Scheduling
+**Source:** User request (2026-05-23)
+**Priority:** Medium — quality-of-life refinement on top of existing notification system
+
+**Problem:** Notifications are currently global — when prayer notifications are enabled, they fire for every selected prayer every day. Some users want different behaviour on different days (e.g., mute Fajr on weekends; silence everything on Friday during travel).
+
+**Proposed solution:** Add a settings UI that lets the user enable/disable each prayer's notification independently per day-of-week (7 × N-prayers matrix, or a simpler "per-day master toggle" if matrix is too dense).
+
+**Why backlog (not Epic yet):**
+- Requires schema decision: matrix vs per-day master vs per-prayer-per-day
+- Storage cost in `SettingsManager` (likely a new `[Int: Set<String>]` keyed by Calendar weekday)
+- Notification scheduler (per-platform) needs to consult the day-of-week before scheduling each fire
+- UI is non-trivial — Settings sheet on macOS/iOS will need a new section
+
+**Promotion criteria:** Promote to EPIC + US in `RELEASE_PLAN.md` when (a) at least one more user requests this OR (b) a v1.7 planning cycle scopes it.
+
+**References:**
+- `iqamah/iOS/PrayerNotificationScheduler.swift` (or equivalent — the per-platform scheduler that would need to consult day-of-week)
+- `Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift` (storage)
+
+---
+
 ## Content & Information
 
 ### ENH-012 — Hadith of the Day

--- a/docs/ID_REGISTRY.md
+++ b/docs/ID_REGISTRY.md
@@ -14,7 +14,7 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 | AC           | AC-0357               | AC-0356           |
 | TC           | TC-0044               | TC-0043           |
 | BUG          | BUG-0069              | BUG-0068          |
-| ENH          | ENH-025               | ENH-024           |
+| ENH          | ENH-026               | ENH-025           |
 
 ---
 
@@ -28,4 +28,4 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 
 ---
 
-**Last Updated:** 2026-05-21 (ENH-001 finish-up — EPIC-0016 + US-0070 promoted; AC-0349 through AC-0356 and TC-0036 through TC-0043 consumed; PrayerActivityAttributes consolidated; watch Option B parity, v1.6 re-detect prompt, dead Views/ cleanup, watch view rename, and CLAUDE.md repo-structure note shipped.)
+**Last Updated:** 2026-05-23 (ENH-025 logged — per-day alert scheduling backlog item from user request.)

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -371,14 +371,14 @@ struct PrayerTimesView: View {
 
     private var moonPhaseSubtitle: String {
         switch currentMoonPhase {
-        case 0 ..< 0.03, 0.97...: return "New Moon"
-        case 0.03 ..< 0.25: return "Waxing Crescent"
-        case 0.25 ..< 0.27: return "First Quarter"
-        case 0.27 ..< 0.48: return "Waxing Gibbous"
-        case 0.48 ..< 0.52: return "Full Moon"
-        case 0.52 ..< 0.73: return "Waning Gibbous"
-        case 0.73 ..< 0.75: return "Last Quarter"
-        default: return "Waning Crescent"
+        case 0 ..< 0.03, 0.97...: "New Moon"
+        case 0.03 ..< 0.25: "Waxing Crescent"
+        case 0.25 ..< 0.27: "First Quarter"
+        case 0.27 ..< 0.48: "Waxing Gibbous"
+        case 0.48 ..< 0.52: "Full Moon"
+        case 0.52 ..< 0.73: "Waning Gibbous"
+        case 0.73 ..< 0.75: "Last Quarter"
+        default: "Waning Crescent"
         }
     }
 

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -166,20 +166,12 @@ struct PrayerTimesView: View {
                         .frame(width: 64, height: 64)
                         .shadow(color: Color.primary.opacity(0.10), radius: 3, x: 0, y: 1)
                 #endif
-
                 Text("Iqamah")
                     .font(.system(size: titleFontSize, weight: .bold, design: .serif))
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [
-                                Color.appGoldDim,
-                                Color(red: 0.85, green: 0.65, blue: 0.13),
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-
+                    .foregroundStyle(LinearGradient(
+                        colors: [Color.appGoldDim, Color(red: 0.85, green: 0.65, blue: 0.13)],
+                        startPoint: .topLeading, endPoint: .bottomTrailing
+                    ))
                 VStack(alignment: .leading, spacing: 2) {
                     Text(displayCityName)
                         .font(.title3.weight(.semibold))
@@ -190,52 +182,32 @@ struct PrayerTimesView: View {
                         .foregroundColor(.secondary)
                         .lineLimit(1)
                 }
-
                 Spacer()
-
                 // ── Qiblah / Settings / About — in header on macOS ──
                 #if os(macOS)
                     HStack(spacing: 16) {
-                        Button(action: { showQiblah = true }) {
-                            VStack(spacing: 2) {
-                                Image(systemName: "location.north.line.fill")
-                                    .font(.title3)
-                                Text("Qiblah")
-                                    .font(.caption2)
-                            }
-                        }
-                        .buttonStyle(.plain)
-                        .help("Qiblah direction")
-                        .accessibilityLabel("Show Qiblah direction")
-
-                        Button(action: { showSettings = true }) {
-                            VStack(spacing: 2) {
-                                Image(systemName: "gearshape")
-                                    .font(.title3)
-                                Text("Settings")
-                                    .font(.caption2)
-                            }
-                        }
-                        .buttonStyle(.plain)
-                        .help("Settings")
-                        .accessibilityLabel("Open settings")
-                        .keyboardShortcut(",", modifiers: .command)
-
-                        Button(action: { showAbout = true }) {
-                            VStack(spacing: 2) {
-                                Image(systemName: "info.circle")
-                                    .font(.title3)
-                                Text("About")
-                                    .font(.caption2)
-                            }
-                        }
-                        .buttonStyle(.plain)
-                        .help("About Iqamah")
-                        .accessibilityLabel("About Iqamah")
+                        topBarIconButton(
+                            systemImage: "location.north.line.fill",
+                            label: "Qiblah",
+                            help: "Qiblah direction",
+                            accessibilityLabel: "Show Qiblah direction"
+                        ) { showQiblah = true }
+                        topBarIconButton(
+                            systemImage: "gearshape",
+                            label: "Settings",
+                            help: "Settings",
+                            accessibilityLabel: "Open settings",
+                            keyboardShortcut: ","
+                        ) { showSettings = true }
+                        topBarIconButton(
+                            systemImage: "info.circle",
+                            label: "About",
+                            help: "About Iqamah",
+                            accessibilityLabel: "About Iqamah"
+                        ) { showAbout = true }
                     }
                     .padding(.trailing, 8)
                 #endif
-
                 // Mute button
                 Button(action: { AdhaaanPlayer.shared.toggleMute() }) {
                     VStack(spacing: 2) {
@@ -245,8 +217,7 @@ struct PrayerTimesView: View {
                             .foregroundColor(AdhaaanPlayer.shared.isMuted ? .secondary : .accentColor)
                             .symbolRenderingMode(.hierarchical)
                         #if os(macOS)
-                            Text(AdhaaanPlayer.shared.isMuted ? "Unmute" : "Mute")
-                                .font(.caption2)
+                            Text(AdhaaanPlayer.shared.isMuted ? "Unmute" : "Mute").font(.caption2)
                         #endif
                     }
                 }
@@ -257,39 +228,29 @@ struct PrayerTimesView: View {
             .padding(.horizontal, 22)
             .padding(.top, 16)
             .padding(.bottom, 10)
-            .background {
-                Rectangle().fill(.ultraThinMaterial)
-            }
+            .background { Rectangle().fill(.ultraThinMaterial) }
 
             // Moon phase preview + Hilal Watch entry
             HStack(spacing: 12) {
                 MoonPhaseView(phase: currentMoonPhase, size: 56)
                     .accessibilityLabel(moonPhaseAccessibilityLabel)
-
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(hijriDateLabel)
-                        .font(.subheadline)
+                    Text(hijriDateLabel).font(.subheadline)
                     Text(isHilalWatchEvening ? "Hilal Watch tonight" : moonPhaseSubtitle)
                         .font(.caption)
                         .foregroundStyle(isHilalWatchEvening ? .orange : .secondary)
                 }
-
                 Spacer()
-
-                Button("Hilal Watch ›") {
-                    openHilalWatch()
-                }
-                .buttonStyle(.borderless)
-                .font(.caption.weight(.medium))
-                .foregroundStyle(Color.appGold)
-                // XCUITest identifier (AC-0322, US-0066)
-                .accessibilityIdentifier("hilalWatchButton")
+                Button("Hilal Watch ›") { openHilalWatch() }
+                    .buttonStyle(.borderless)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(Color.appGold)
+                    // XCUITest identifier (AC-0322, US-0066)
+                    .accessibilityIdentifier("hilalWatchButton")
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background {
-                Rectangle().fill(.ultraThinMaterial)
-            }
+            .background { Rectangle().fill(.ultraThinMaterial) }
 
             Divider()
 
@@ -298,9 +259,7 @@ struct PrayerTimesView: View {
                 .font(.subheadline.bold())
                 .padding(.vertical, 12)
                 .frame(maxWidth: .infinity)
-                .background {
-                    Rectangle().fill(.ultraThinMaterial.opacity(0.6))
-                }
+                .background { Rectangle().fill(.ultraThinMaterial.opacity(0.6)) }
 
             // Prayer times table — pass the shared expandedRowID so the adhaan
             // picker can open/close on macOS (was using .constant(nil) default).
@@ -411,17 +370,15 @@ struct PrayerTimesView: View {
     }
 
     private var moonPhaseSubtitle: String {
-        let phase = currentMoonPhase
-        switch phase {
-        case 0 ..< 0.03: return "New Moon"
+        switch currentMoonPhase {
+        case 0 ..< 0.03, 0.97...: return "New Moon"
         case 0.03 ..< 0.25: return "Waxing Crescent"
         case 0.25 ..< 0.27: return "First Quarter"
         case 0.27 ..< 0.48: return "Waxing Gibbous"
         case 0.48 ..< 0.52: return "Full Moon"
         case 0.52 ..< 0.73: return "Waning Gibbous"
         case 0.73 ..< 0.75: return "Last Quarter"
-        case 0.75 ..< 0.97: return "Waning Crescent"
-        default: return "New Moon"
+        default: return "Waning Crescent"
         }
     }
 
@@ -463,27 +420,21 @@ struct PrayerTimesView: View {
     private func calculatePrayerTimes() {
         let timezone = TimeZone(identifier: city.timezone) ?? .current
         let calculator = PrayerCalculator(
-            coordinate: city.coordinate,
-            timezone: timezone,
-            method: calculationMethod,
-            asrMethod: asrMethod
+            coordinate: city.coordinate, timezone: timezone,
+            method: calculationMethod, asrMethod: asrMethod
         )
-
         do {
             prayerTimes = try calculator.calculate(for: currentDate)
         } catch {
-            // Log error and show user-friendly message
+            // Log error; in production, show alert to user
             print("Prayer calculation error: \(error.localizedDescription)")
-            // In production, show alert to user
         }
     }
 
     private func updateDate() {
         let newDate = Date()
-        let calendar = Calendar.current
-
         // Check if day has changed
-        if !calendar.isDate(newDate, inSameDayAs: currentDate) {
+        if !Calendar.current.isDate(newDate, inSameDayAs: currentDate) {
             expandedRowID = nil
             currentDate = newDate
             calculatePrayerTimes()
@@ -491,7 +442,6 @@ struct PrayerTimesView: View {
         } else {
             currentDate = newDate
         }
-
         #if os(iOS)
             // Mirror macOS AppDelegate.triggerAdhaanIfNeeded: play the selected adhaan
             // when a prayer time arrives while the app is in the foreground.
@@ -499,6 +449,37 @@ struct PrayerTimesView: View {
         #endif
     }
 }
+
+// MARK: - PrayerTimesView+TopBar (macOS only)
+
+#if os(macOS)
+    private extension PrayerTimesView {
+        @ViewBuilder
+        func topBarIconButton(
+            systemImage: String,
+            label: String,
+            help: String,
+            accessibilityLabel: String,
+            keyboardShortcut: KeyEquivalent? = nil,
+            action: @escaping () -> Void
+        ) -> some View {
+            let button = Button(action: action) {
+                VStack(spacing: 2) {
+                    Image(systemName: systemImage).font(.title3)
+                    Text(label).font(.caption2)
+                }
+            }
+            .buttonStyle(.plain)
+            .help(help)
+            .accessibilityLabel(accessibilityLabel)
+            if let key = keyboardShortcut {
+                button.keyboardShortcut(key, modifiers: .command)
+            } else {
+                button
+            }
+        }
+    }
+#endif
 
 // MARK: - PrayerTimesView+AdhaanTrigger (iOS only)
 

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -195,18 +195,26 @@ struct PrayerTimesView: View {
 
                 // ── Qiblah / Settings / About — in header on macOS ──
                 #if os(macOS)
-                    HStack(spacing: 2) {
+                    HStack(spacing: 16) {
                         Button(action: { showQiblah = true }) {
-                            Image(systemName: "location.north.line.fill")
-                                .font(.title3)
+                            VStack(spacing: 2) {
+                                Image(systemName: "location.north.line.fill")
+                                    .font(.title3)
+                                Text("Qiblah")
+                                    .font(.caption2)
+                            }
                         }
                         .buttonStyle(.plain)
                         .help("Qiblah direction")
                         .accessibilityLabel("Show Qiblah direction")
 
                         Button(action: { showSettings = true }) {
-                            Image(systemName: "gearshape")
-                                .font(.title3)
+                            VStack(spacing: 2) {
+                                Image(systemName: "gearshape")
+                                    .font(.title3)
+                                Text("Settings")
+                                    .font(.caption2)
+                            }
                         }
                         .buttonStyle(.plain)
                         .help("Settings")
@@ -214,8 +222,12 @@ struct PrayerTimesView: View {
                         .keyboardShortcut(",", modifiers: .command)
 
                         Button(action: { showAbout = true }) {
-                            Image(systemName: "info.circle")
-                                .font(.title3)
+                            VStack(spacing: 2) {
+                                Image(systemName: "info.circle")
+                                    .font(.title3)
+                                Text("About")
+                                    .font(.caption2)
+                            }
                         }
                         .buttonStyle(.plain)
                         .help("About Iqamah")
@@ -226,11 +238,17 @@ struct PrayerTimesView: View {
 
                 // Mute button
                 Button(action: { AdhaaanPlayer.shared.toggleMute() }) {
-                    Image(systemName: AdhaaanPlayer.shared.isMuted
-                        ? "speaker.slash.fill" : "speaker.wave.2.fill")
-                        .font(.title3)
-                        .foregroundColor(AdhaaanPlayer.shared.isMuted ? .secondary : .accentColor)
-                        .symbolRenderingMode(.hierarchical)
+                    VStack(spacing: 2) {
+                        Image(systemName: AdhaaanPlayer.shared.isMuted
+                            ? "speaker.slash.fill" : "speaker.wave.2.fill")
+                            .font(.title3)
+                            .foregroundColor(AdhaaanPlayer.shared.isMuted ? .secondary : .accentColor)
+                            .symbolRenderingMode(.hierarchical)
+                        #if os(macOS)
+                            Text(AdhaaanPlayer.shared.isMuted ? "Unmute" : "Mute")
+                                .font(.caption2)
+                        #endif
+                    }
                 }
                 .buttonStyle(.plain)
                 .help(AdhaaanPlayer.shared.isMuted ? "Unmute Adhaan" : "Mute Adhaan")

--- a/iqamah/Views/SettingsSheetView.swift
+++ b/iqamah/Views/SettingsSheetView.swift
@@ -457,30 +457,10 @@ struct SettingsSheetView: View {
                 }
                 recommendationLabel = CalculationMethod.recommendationLabel(forCountryCode: country.code)
             }
-            .alert(
-                "Launch at Login",
-                isPresented: Binding(
-                    get: { loginItemError != nil },
-                    set: { if !$0 { loginItemError = nil } }
-                ),
-                presenting: loginItemError
-            ) { _ in
-                Button("OK", role: .cancel) { loginItemError = nil }
-            } message: { msg in
-                Text(msg)
-            }
-            .alert(
-                "Approve in Login Items",
-                isPresented: Binding(
-                    get: { loginItemInfo != nil },
-                    set: { if !$0 { loginItemInfo = nil } }
-                ),
-                presenting: loginItemInfo
-            ) { _ in
-                Button("OK", role: .cancel) { loginItemInfo = nil }
-            } message: { msg in
-                Text(msg)
-            }
+            .modifier(LaunchAtLoginAlerts(
+                error: $loginItemError,
+                info: $loginItemInfo
+            ))
         #endif
     }
 }
@@ -553,6 +533,29 @@ private extension SettingsSheetView {
         onSave(city, selectedMethod, selectedAsrMethod)
     }
 }
+
+// MARK: - Launch at Login alerts modifier (macOS)
+
+#if os(macOS)
+    private struct LaunchAtLoginAlerts: ViewModifier {
+        @Binding var error: String?
+        @Binding var info: String?
+
+        private func presentation(_ value: Binding<String?>) -> Binding<Bool> {
+            Binding(get: { value.wrappedValue != nil }, set: { if !$0 { value.wrappedValue = nil } })
+        }
+
+        func body(content: Content) -> some View {
+            content
+                .alert("Launch at Login", isPresented: presentation($error), presenting: error) { _ in
+                    Button("OK", role: .cancel) { error = nil }
+                } message: { msg in Text(msg) }
+                .alert("Approve in Login Items", isPresented: presentation($info), presenting: info) { _ in
+                    Button("OK", role: .cancel) { info = nil }
+                } message: { msg in Text(msg) }
+        }
+    }
+#endif
 
 // MARK: - Hilal Watch settings (extracted to keep SettingsSheetView under line limit)
 

--- a/iqamah/Views/SettingsSheetView.swift
+++ b/iqamah/Views/SettingsSheetView.swift
@@ -34,6 +34,8 @@ struct SettingsSheetView: View {
     @ObservedObject private var settings = SettingsManager.shared
     #if os(macOS)
         @State private var launchAtLogin = false
+        @State private var loginItemError: String?
+        @State private var loginItemInfo: String?
     #endif
     @State private var isDetectingLocation = false
     /// Transient highlight pulse on the Detect button when the user arrives
@@ -255,13 +257,7 @@ struct SettingsSheetView: View {
             }
             .toggleStyle(.switch)
             .onChange(of: launchAtLogin) { _, enabled in
-                do {
-                    if enabled {
-                        try SMAppService.mainApp.register()
-                    } else {
-                        try SMAppService.mainApp.unregister()
-                    }
-                } catch { launchAtLogin = !enabled }
+                handleLaunchAtLoginChange(enabled: enabled)
             }
         #endif
         Picker("Appearance", selection: $selectedAppearance) {
@@ -461,6 +457,30 @@ struct SettingsSheetView: View {
                 }
                 recommendationLabel = CalculationMethod.recommendationLabel(forCountryCode: country.code)
             }
+            .alert(
+                "Launch at Login",
+                isPresented: Binding(
+                    get: { loginItemError != nil },
+                    set: { if !$0 { loginItemError = nil } }
+                ),
+                presenting: loginItemError
+            ) { _ in
+                Button("OK", role: .cancel) { loginItemError = nil }
+            } message: { msg in
+                Text(msg)
+            }
+            .alert(
+                "Approve in Login Items",
+                isPresented: Binding(
+                    get: { loginItemInfo != nil },
+                    set: { if !$0 { loginItemInfo = nil } }
+                ),
+                presenting: loginItemInfo
+            ) { _ in
+                Button("OK", role: .cancel) { loginItemInfo = nil }
+            } message: { msg in
+                Text(msg)
+            }
         #endif
     }
 }
@@ -503,6 +523,28 @@ private extension SettingsSheetView {
         let suggested = CalculationMethod.suggested(forCountryCode: currentCity.countryCode)
         userOverrodeMethod = (currentMethod != suggested)
     }
+
+    #if os(macOS)
+        func handleLaunchAtLoginChange(enabled: Bool) {
+            do {
+                if enabled {
+                    try SMAppService.mainApp.register()
+                    // Re-read status: .requiresApproval is a success state
+                    // awaiting user confirmation in System Settings → Login Items.
+                    if SMAppService.mainApp.status == .requiresApproval {
+                        loginItemInfo = "Iqamah is asking to launch at login. Please approve in System Settings → General → Login Items."
+                    }
+                    // Leave toggle ON regardless of approval state.
+                } else {
+                    try SMAppService.mainApp.unregister()
+                }
+            } catch {
+                print("SMAppService register failed: \(error)")
+                loginItemError = "Couldn't enable start at login: \(error.localizedDescription). Try opening System Settings → General → Login Items to enable Iqamah."
+                launchAtLogin = !enabled
+            }
+        }
+    #endif
 
     func save() {
         guard let city = selectedCity else { return }

--- a/iqamah/iOS/PrayerActivityManager.swift
+++ b/iqamah/iOS/PrayerActivityManager.swift
@@ -11,6 +11,7 @@
         private init() {}
 
         private var currentActivity: Activity<PrayerActivityAttributes>?
+        private var rolloverTimer: Timer?
 
         // MARK: - Public API
 
@@ -21,6 +22,12 @@
                 return
             }
             guard let state = buildContentState(settings: settings) else { return }
+
+            // staleDate ~1 minute after the next prayer time so iOS dims the
+            // Live Activity and prompts a refresh once it's passed (avoids
+            // the count-up timer issue where Text(date, style: .timer)
+            // flips to count-up after the target passes).
+            let staleDate = state.nextPrayerTime.addingTimeInterval(60)
 
             // Adopt any surviving activity from a previous session so we never run
             // two concurrent Live Activities (which causes duplicate lock-screen banners).
@@ -38,7 +45,7 @@
             }
 
             if let activity = currentActivity {
-                await activity.update(ActivityContent(state: state, staleDate: nil))
+                await activity.update(ActivityContent(state: state, staleDate: staleDate))
             } else {
                 let attributes = PrayerActivityAttributes(
                     cityName: settings.activeCityName,
@@ -47,19 +54,39 @@
                 do {
                     currentActivity = try Activity.request(
                         attributes: attributes,
-                        content: ActivityContent(state: state, staleDate: nil)
+                        content: ActivityContent(state: state, staleDate: staleDate)
                     )
                 } catch {
                     print("[PrayerActivityManager] Failed to start activity: \(error)")
                 }
             }
+
+            // Schedule a foreground-only rollover so a foregrounded (or recently
+            // backgrounded) app advances to the next prayer +1s after the current
+            // one passes. Full background reliability still requires push-token
+            // LA updates + BGAppRefreshTask (follow-up).
+            scheduleRollover(at: state.nextPrayerTime)
         }
 
         func endActivity() async {
+            rolloverTimer?.invalidate()
+            rolloverTimer = nil
             if let activity = currentActivity {
                 await activity.end(ActivityContent(state: activity.content.state, staleDate: nil), dismissalPolicy: .immediate)
             }
             currentActivity = nil
+        }
+
+        private func scheduleRollover(at fireDate: Date) {
+            rolloverTimer?.invalidate()
+            let delay = max(1, fireDate.timeIntervalSinceNow + 1)
+            let timer = Timer(timeInterval: delay, repeats: false) { [weak self] _ in
+                Task { @MainActor in
+                    await self?.startOrUpdateActivity(settings: SettingsManager.shared)
+                }
+            }
+            rolloverTimer = timer
+            RunLoop.main.add(timer, forMode: .common)
         }
 
         // MARK: - Private


### PR DESCRIPTION
## Summary

Four small, independent fixes/polish items uncovered while testing builds 12–14. Each commit stands alone.

### 🐛 `405256a` fix(ios-la): refresh Live Activity on prayer rollover [P0]

User-reported: iOS Live Activity / Dynamic Island stayed stuck on a passed prayer with a count-up timer (e.g. Maghrib still showing at 11:15 PM, 2h33m after Maghrib passed).

**Root cause:** `PrayerActivityManager` only called `Activity.update` on app-active / settings change. `staleDate` was nil, so iOS never dimmed the stale content either. `Text(date, style: .timer)` flips to count-up after the target passes — explains the symptom.

**Fix:**
- Set `staleDate = state.nextPrayerTime + 60s` so iOS dims the LA once the prayer passes.
- Schedule a foreground `Timer` at next-prayer +1s that re-evaluates the activity state and pushes a fresh `ContentState` — so a foregrounded or recently-backgrounded app advances automatically.

**Known follow-up:** full background reliability needs push-token Live Activities + server pushes (or BGAppRefreshTask). Foreground/recent-background covered today; long-suspended app still drifts until reopened.

### 🐛 `d2d623e` fix(macos): surface Start-on-Login registration errors

User-reported: macOS \"Start on Login\" toggle flips ON then auto-reverts to OFF.

**Root cause:** `SMAppService.mainApp.register()` was throwing (or returning `.requiresApproval`); the `catch` silently set the toggle back without logging or alerting.

**Fix:**
- Log the actual `NSError` to Console.
- Present an alert with the error's `localizedDescription` and instructions to enable via System Settings → General → Login Items.
- Handle `.requiresApproval` as a success state — toggle stays ON with a friendlier prompt.
- `loadInitialState()` already re-reads `SMAppService.mainApp.status == .enabled` on appear, so the toggle reflects reality even after out-of-band approval.

### ✨ `1a3ec44` feat(macos-ui): add labels + spacing to top bar buttons

User-requested: the macOS Qiblah/Settings/About/Mute buttons were icon-only with 2pt spacing — hard to scan and easy to mis-tap.

**Fix:** Each icon is now `VStack { Image; Text(...) }` with `.caption2` labels, and the action-cluster spacing is bumped from 2pt → 16pt. iOS path unchanged (the action cluster is already `#if os(macOS)`-wrapped, and the shared mute button's new caption is wrapped in its own macOS guard).

Captions: \"Qiblah\", \"Settings\", \"About\", \"Mute\"/\"Unmute\". Header height grows ~12pt; max window height 680pt leaves headroom.

### 📋 `0ab2a61` docs(enh): log ENH-025 per-day alert scheduling

Backlog entry from user request: a settings UI letting users enable/disable prayer notifications independently per day-of-week. Schema decision and UI design deferred — promote to EPIC when a v1.7 planning cycle scopes it. Added under Audio & Adhan section (next to ENH-024 Critical Alerts). `docs/ID_REGISTRY.md` bumped to next ENH-026.

## Discovered (out-of-scope, filed as follow-up)

While verifying the LA fix, `xcodebuild` for the iOS target failed at package graph resolution: `swift-snapshot-testing` 1.17+ vs `swift-syntax` version conflict. Pre-existing — not introduced by this PR. macOS `xcodebuild` (used to verify Start-on-Login + toolbar fixes) is unaffected and green. Worth a separate task to pin or update `swift-snapshot-testing`.

## Relationship to PR #132

This PR ships against `main` independently of the Fasting Mode foundation PR (#132). #132 brings 1.6.0/15 + new Core APIs; this PR ships shipped-product bug fixes the user wants in the same v1.6.0 release. Either PR can land first; #132's rebase on top of this is trivial (no overlapping files).

## Test plan

- [x] `cd Packages/IqamahCore && swift build` — clean (all 4 commits)
- [x] `xcodebuild -scheme iqamah -destination 'generic/platform=macOS' build` — \`** BUILD SUCCEEDED **\` for the macOS-touching commits
- [ ] iOS xcodebuild — blocked by pre-existing `swift-snapshot-testing` conflict; CI on this PR will reveal whether the conflict reproduces in CI or is local-only
- [ ] Manual: confirm Dynamic Island advances past a prayer on iPhone after building locally
- [ ] Manual: confirm Start-on-Login alert appears when toggled in a debug build, and that toggle persists ON in a TestFlight build
- [ ] Manual: visually verify the macOS toolbar captions render without clipping at default + max window sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)