### PR TITLE
fix(ios): CFBundleVersion substitution so extensions match parent

### DIFF
--- a/iqamah/iOS/Info.plist
+++ b/iqamah/iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Iqamah uses your location to calculate accurate prayer times for your area.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
## Summary

`iqamah/iOS/Info.plist` had a literal `<string>1</string>` for `CFBundleVersion`, overriding the iOS target's `CURRENT_PROJECT_VERSION = 15`. The iOS app would have shipped as build 1 while `IqamahWidget`/`IqamahLiveActivity` shipped as build 15, hitting TestFlight's `CFBundleVersion of an app extension must match that of its containing parent app` rejection.

Switch to `$(CURRENT_PROJECT_VERSION)` substitution — the same pattern the file already uses for `$(MARKETING_VERSION)` on the line directly above. Future bumps now auto-propagate from the build setting.

## How this slipped past PR #132

PR #132's `eecf893` bumped every extension Info.plist literal from `1` to `15`, plus all pbxproj `CURRENT_PROJECT_VERSION` entries. It did **not** touch `iqamah/iOS/Info.plist`, which had `<string>1</string>` already (set during the v1.5.0 → 1.6.0 cycle). Surface discovered only when I ran iOS `xcodebuild` and grepped for the mismatch warning while triaging an unrelated package-resolution claim.

## Verification

- `plutil -lint iqamah/iOS/Info.plist` → OK
- `xcodebuild -project iqamah.xcodeproj -scheme iqamah-iOS -configuration Debug -destination 'generic/platform=iOS' build` → `** BUILD SUCCEEDED **` with no `CFBundleVersion of an app extension...` warning (which DID appear pre-fix).

## Test plan

- [x] iOS xcodebuild clean
- [ ] CI on this PR confirms across platforms
- [ ] TestFlight upload validation post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)