### PR TITLE
docs: ENH-026 + iOS xcodebuild scheme clarification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Open `iqamah.xcodeproj` in Xcode and build/run (Cmd+R). Alternatively:
 
 ```bash
+# macOS:
 xcodebuild -project iqamah.xcodeproj -scheme iqamah -configuration Debug build
+# iOS:
+xcodebuild -project iqamah.xcodeproj -scheme iqamah-iOS -configuration Debug -destination 'generic/platform=iOS' build
 ```
 
 There are no external dependencies, package managers, or test targets.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Press **Cmd+R** in Xcode. No package manager or external dependencies needed.
 From the command line:
 
 ```bash
+# macOS:
 xcodebuild -project iqamah.xcodeproj -scheme iqamah -configuration Debug build
+# iOS:
+xcodebuild -project iqamah.xcodeproj -scheme iqamah-iOS -configuration Debug -destination 'generic/platform=iOS' build
 ```
 
 ---
@@ -113,8 +116,12 @@ iqamah/
 ## Testing
 
 ```bash
+# macOS:
 xcodebuild -project iqamah.xcodeproj -scheme iqamah -configuration Debug test \
   -destination 'platform=macOS'
+# iOS:
+xcodebuild -project iqamah.xcodeproj -scheme iqamah-iOS -configuration Debug test \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
 ```
 
 The test suite covers prayer calculation accuracy, city model validation, Qiblah bearing, Hijri date conversion, settings persistence, Adhaan model, and calculation method country mapping. Target: ≥80% code coverage.

--- a/docs/ENHANCEMENTS.md
+++ b/docs/ENHANCEMENTS.md
@@ -391,6 +391,29 @@ The audit showed Iqamah is doing everything correctly within Apple's default con
 
 ---
 
+### ENH-026 — Background-reliable Live Activity updates
+
+**Status:** Backlog
+**Source:** Follow-up from v1.6.0 LA rollover fix (PR #133, commit 405256a)
+
+**Problem:** v1.6.0 ships a foreground/recent-background fix for the Live Activity "stuck on passed prayer" bug — `staleDate` + a `Timer` that re-evaluates the activity state at the next prayer time. If the app is suspended (long-backgrounded, terminated, or memory-pressured), the Timer doesn't fire and the Live Activity / Dynamic Island can drift again until the user reopens the app.
+
+**Proposed solution:** Move from local Activity updates to push-token Live Activities. Each scheduled prayer time becomes a server-pushed `ActivityContent` update via APNs (or a silent local APNs via `Activity<...>.pushToken` if Apple's documentation allows it without a server). Pair with `BGAppRefreshTask` registration so the app can re-arm the next push window on launch / background refresh.
+
+**Why backlog (not Epic yet):**
+- Requires a backend (or commitment to a server-light solution like a cheap Cloudflare Worker / Lambda) — design + cost decision.
+- Push payload format + retry strategy needs design.
+- Existing code already produces a `FastingDayState` per evaluation — pure-data side already done.
+
+**Promotion criteria:** Promote to EPIC + US when the team commits to a notification backend (a separate decision the indie/solo dev cycle will gate on).
+
+**References:**
+- `iqamah/iOS/PrayerActivityManager.swift` — current foreground Timer
+- `IqamahLiveActivity/PrayerActivityAttributes.swift` — ContentState struct
+- Apple docs: ActivityKit push-token updates
+
+---
+
 ### ENH-025 — Per-day Alert Scheduling
 **Source:** User request (2026-05-23)
 **Priority:** Medium — quality-of-life refinement on top of existing notification system

--- a/docs/ID_REGISTRY.md
+++ b/docs/ID_REGISTRY.md
@@ -14,7 +14,7 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 | AC           | AC-0357               | AC-0356           |
 | TC           | TC-0044               | TC-0043           |
 | BUG          | BUG-0069              | BUG-0068          |
-| ENH          | ENH-026               | ENH-025           |
+| ENH          | ENH-027               | ENH-026           |
 
 ---
 
@@ -28,4 +28,4 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 
 ---
 
-**Last Updated:** 2026-05-23 (ENH-025 logged — per-day alert scheduling backlog item from user request.)
+**Last Updated:** 2026-05-23 (ENH-026 logged — background-reliable LA updates follow-up from v1.6.0 PR #133.)

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -85,7 +85,7 @@ Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 **TC-0002 (AC-0170) — macOS app builds clean after extraction**
 Type: Regression · Preconditions: Branch 1 applied
 Steps:
-  1. `xcodebuild -project iqamah.xcodeproj -scheme iqamah -configuration Debug build`
+  1. `xcodebuild -project iqamah.xcodeproj -scheme iqamah -configuration Debug build` (macOS; for iOS use `-scheme iqamah-iOS -destination 'generic/platform=iOS'`)
   2. Compare warning count to pre-extraction baseline
 Expected: BUILD SUCCEEDED, no new warnings introduced by the move
 Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:


### PR DESCRIPTION
## Summary

Small two-item docs PR for v1.6.0 hygiene:

- **ENH-026 — Background-reliable Live Activity updates.** Logged in `docs/ENHANCEMENTS.md` as a follow-up to the v1.6.0 LA rollover fix (PR #133). Captures the gap that the current `Timer`/`staleDate` solution leaves when the app is fully suspended, and sketches the push-token + `BGAppRefreshTask` path forward. Promotion gated on a backend decision.
- **iOS xcodebuild scheme clarification.** `README.md`, `CLAUDE.md`, and `docs/TEST_CASES.md` (TC-0002) now mention `iqamah-iOS` alongside the macOS `iqamah` scheme with a `generic/platform=iOS` destination example. Prevents future contributors (and agents) from repeating the recent "iqamah scheme has no iOS destination" triage detour.
- `docs/ID_REGISTRY.md` bumped: next ENH is now ENH-027.

## Test plan

- [ ] Visual review of ENH-026 entry placement in `docs/ENHANCEMENTS.md`
- [ ] `docs/ID_REGISTRY.md` reflects ENH-027 next / ENH-026 last assigned
- [ ] README + CLAUDE.md xcodebuild blocks render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)