### PR TITLE
feat(ui): Fasting Mode UI wiring (Tasks 10–14 of EPIC-0017)

### DIFF
--- a/IqamahLiveActivity/PrayerActivityAttributes.swift
+++ b/IqamahLiveActivity/PrayerActivityAttributes.swift
@@ -10,27 +10,50 @@ struct PrayerActivityAttributes: ActivityAttributes {
     let cityName: String
     let methodName: String
 
-    init(cityName: String, methodName: String) {
-        self.cityName = cityName
-        self.methodName = methodName
-    }
-
     struct ContentState: Codable, Hashable {
         let nextPrayerName: String
         let nextPrayerTime: Date
         let followingPrayerName: String
         let moonPhase: Double
         let hijriDateString: String
+        // v1.6 additions (AC-0370) — optional with default-nil so v1.5 in-flight
+        // activities decode cleanly under v1.6.
+        var fastingActive: Bool?
+        var fastingTriggerRaw: String?
 
         init(
             nextPrayerName: String, nextPrayerTime: Date,
-            followingPrayerName: String, moonPhase: Double, hijriDateString: String
+            followingPrayerName: String, moonPhase: Double, hijriDateString: String,
+            fastingActive: Bool? = nil, fastingTriggerRaw: String? = nil
         ) {
             self.nextPrayerName = nextPrayerName
             self.nextPrayerTime = nextPrayerTime
             self.followingPrayerName = followingPrayerName
             self.moonPhase = moonPhase
             self.hijriDateString = hijriDateString
+            self.fastingActive = fastingActive
+            self.fastingTriggerRaw = fastingTriggerRaw
+        }
+
+        // Forward-compatible decoder — `fastingActive` and `fastingTriggerRaw`
+        // are missing from v1.5 payloads; default to nil rather than throw.
+        enum CodingKeys: String, CodingKey {
+            case nextPrayerName, nextPrayerTime, followingPrayerName
+            case moonPhase, hijriDateString
+            case fastingActive, fastingTriggerRaw
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            try self.init(
+                nextPrayerName: c.decode(String.self, forKey: .nextPrayerName),
+                nextPrayerTime: c.decode(Date.self, forKey: .nextPrayerTime),
+                followingPrayerName: c.decode(String.self, forKey: .followingPrayerName),
+                moonPhase: c.decode(Double.self, forKey: .moonPhase),
+                hijriDateString: c.decode(String.self, forKey: .hijriDateString),
+                fastingActive: c.decodeIfPresent(Bool.self, forKey: .fastingActive),
+                fastingTriggerRaw: c.decodeIfPresent(String.self, forKey: .fastingTriggerRaw)
+            )
         }
     }
 }

--- a/IqamahLiveActivity/PrayerLiveActivityView.swift
+++ b/IqamahLiveActivity/PrayerLiveActivityView.swift
@@ -6,6 +6,37 @@ import WidgetKit
 
 private let activityGold = Color(red: 1.0, green: 0.839, blue: 0.039)
 
+// MARK: - Fasting Mode relabel helper (AC-0370)
+
+//
+// IqamahCore is intentionally not linked into the Live Activity extension to
+// keep the extension binary small. The relabel logic is tiny — mirror it here
+// rather than pull in the framework. Stays in sync with
+// FastingLabelFormatter.relabel(...) in IqamahCore.
+private let liveActivityRelabelWindow: TimeInterval = 2 * 60 * 60
+
+private func displayedNextPrayerName(
+    _ context: ActivityViewContext<PrayerActivityAttributes>
+) -> String {
+    guard context.state.fastingActive == true,
+          let triggerRaw = context.state.fastingTriggerRaw,
+          !triggerRaw.isEmpty else {
+        return context.state.nextPrayerName
+    }
+    let newLabel: String
+    switch context.state.nextPrayerName {
+    case "Fajr": newLabel = "Suhoor"
+    case "Maghrib": newLabel = "Iftar"
+    default: return context.state.nextPrayerName
+    }
+    let secondsUntil = context.state.nextPrayerTime.timeIntervalSinceNow
+    guard (0 ... liveActivityRelabelWindow).contains(secondsUntil) else {
+        return context.state.nextPrayerName
+    }
+    let glyph = triggerRaw == "autoRamadan" ? "🌙" : "🕗"
+    return "\(glyph) \(newLabel)"
+}
+
 // MARK: - Inline crescent (MoonPhaseView lives in macOS target; can't import it here)
 
 private struct CrescentView: View {
@@ -67,7 +98,7 @@ struct PrayerLiveActivityView: Widget {
             } compactLeading: {
                 HStack(spacing: 4) {
                     Circle().fill(activityGold).frame(width: 7, height: 7)
-                    Text(context.state.nextPrayerName)
+                    Text(displayedNextPrayerName(context))
                         .font(.system(size: 13, weight: .bold))
                         .foregroundStyle(activityGold)
                 }
@@ -112,7 +143,7 @@ private struct ExpandedTrailingView: View {
     let context: ActivityViewContext<PrayerActivityAttributes>
     var body: some View {
         VStack(alignment: .trailing, spacing: 2) {
-            Text(context.state.nextPrayerName)
+            Text(displayedNextPrayerName(context))
                 .font(.system(size: 22, weight: .bold))
                 .foregroundStyle(activityGold)
             Text(context.state.nextPrayerTime, style: .timer)
@@ -164,7 +195,7 @@ private struct LockScreenLiveActivityView: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(context.state.nextPrayerName)
+                    Text(displayedNextPrayerName(context))
                         .font(.system(size: 15, weight: .bold))
                         .foregroundStyle(activityGold)
                     Text(context.state.nextPrayerTime.formatted(.dateTime.hour().minute()))

--- a/IqamahWatch/PrayerTimesTab.swift
+++ b/IqamahWatch/PrayerTimesTab.swift
@@ -23,7 +23,8 @@ struct PrayerTimesTab: View {
                             prayer: prayer,
                             isNext: prayer.name == nextPrayerName,
                             gold: gold,
-                            timeString: formattedTime(prayer.time)
+                            timeString: formattedTime(prayer.time),
+                            displayName: displayName(for: prayer)
                         )
                     }
                 }
@@ -42,6 +43,24 @@ struct PrayerTimesTab: View {
         let f = DateFormatter()
         f.dateFormat = settings.use24HourTime ? "HH:mm" : "h:mm"
         return f.string(from: date)
+    }
+
+    /// AC-0369 (watchOS): apply FastingLabelFormatter relabel within 2h window.
+    private func displayName(for prayer: (name: String, time: Date)) -> String {
+        let tz = TimeZone(identifier: settings.activeTimezoneIdentifier) ?? .current
+        let state = FastingModeEngine.evaluate(
+            for: Date(),
+            settings: settings.fastingModeSettings,
+            calculationMethod: settings.calculationMethod,
+            hijriCalendar: Calendar(identifier: .islamicUmmAlQura),
+            timezone: tz
+        )
+        return FastingLabelFormatter.relabel(
+            prayerName: prayer.name,
+            prayerTime: prayer.time,
+            currentTime: Date(),
+            state: state
+        )
     }
 
     private var hijriHeader: String {
@@ -78,11 +97,12 @@ private struct PrayerRow: View {
     let isNext: Bool
     let gold: Color
     let timeString: String
+    let displayName: String
 
     var body: some View {
         let font: Font = isNext ? .system(size: 13, weight: .bold) : .system(size: 13)
         HStack {
-            Text(prayer.name).font(font)
+            Text(displayName).font(font)
             Spacer()
             Text(timeString).font(font)
         }

--- a/IqamahWatchWidget/IqamahWatchWidget.swift
+++ b/IqamahWatchWidget/IqamahWatchWidget.swift
@@ -14,7 +14,7 @@ struct RectangularComplicationView: View {
                 .foregroundStyle(.secondary)
                 .widgetAccentable()
             HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text(entry.nextPrayerName)
+                Text(entry.displayedNextPrayerName)
                     .font(.system(size: 15, weight: .bold))
                 Text(entry.countdown)
                     .font(.system(size: 15, weight: .bold))
@@ -94,7 +94,7 @@ struct InlineComplicationView: View {
     var body: some View {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
-        return Text("\(entry.nextPrayerName) at \(formatter.string(from: entry.nextPrayerTime))")
+        return Text("\(entry.displayedNextPrayerName) at \(formatter.string(from: entry.nextPrayerTime))")
             .widgetAccentable()
     }
 }

--- a/IqamahWatchWidget/PrayerEntry.swift
+++ b/IqamahWatchWidget/PrayerEntry.swift
@@ -7,6 +7,46 @@ struct PrayerEntry: TimelineEntry {
     let nextPrayerTime: Date
     let cityName: String
     let methodName: String
+    // AC-0370: Fasting Mode state captured for this entry's `date`. Defaults
+    // keep existing call sites (and TimelineTests) compiling unchanged.
+    let fastingActive: Bool
+    let fastingTriggerRaw: String?
+
+    init(
+        date: Date,
+        nextPrayerName: String,
+        nextPrayerTime: Date,
+        cityName: String,
+        methodName: String,
+        fastingActive: Bool = false,
+        fastingTriggerRaw: String? = nil
+    ) {
+        self.date = date
+        self.nextPrayerName = nextPrayerName
+        self.nextPrayerTime = nextPrayerTime
+        self.cityName = cityName
+        self.methodName = methodName
+        self.fastingActive = fastingActive
+        self.fastingTriggerRaw = fastingTriggerRaw
+    }
+
+    /// Apply FastingLabelFormatter relabel when active and within 2h.
+    var displayedNextPrayerName: String {
+        guard fastingActive,
+              let trigger = fastingTriggerRaw, !trigger.isEmpty else {
+            return nextPrayerName
+        }
+        let newLabel: String
+        switch nextPrayerName {
+        case "Fajr": newLabel = "Suhoor"
+        case "Maghrib": newLabel = "Iftar"
+        default: return nextPrayerName
+        }
+        let secondsUntil = nextPrayerTime.timeIntervalSince(date)
+        guard (0 ... (2 * 60 * 60)).contains(secondsUntil) else { return nextPrayerName }
+        let glyph = trigger == "autoRamadan" ? "🌙" : "🕗"
+        return "\(glyph) \(newLabel)"
+    }
 
     /// Formatted relative countdown string, e.g. "2h 14m" or "32m"
     var countdown: String {

--- a/IqamahWatchWidget/PrayerTimelineProvider.swift
+++ b/IqamahWatchWidget/PrayerTimelineProvider.swift
@@ -59,12 +59,22 @@ struct PrayerTimelineProvider: TimelineProvider {
             else { continue }
 
             for prayer in times.prayers where prayer.name != "Sunrise" && prayer.time > cursor {
+                // AC-0370: capture Fasting Mode state for the moment this entry becomes active.
+                let fastingState = FastingModeEngine.evaluate(
+                    for: cursor,
+                    settings: settings.fastingModeSettings,
+                    calculationMethod: settings.calculationMethod,
+                    hijriCalendar: Calendar(identifier: .islamicUmmAlQura),
+                    timezone: timezone
+                )
                 entries.append(PrayerEntry(
                     date: cursor,
                     nextPrayerName: prayer.name,
                     nextPrayerTime: prayer.time,
                     cityName: cityName,
-                    methodName: methodName
+                    methodName: methodName,
+                    fastingActive: fastingState.isActive,
+                    fastingTriggerRaw: fastingState.trigger?.rawValue
                 ))
                 cursor = prayer.time
             }

--- a/IqamahWidget/InlineWidgetView.swift
+++ b/IqamahWidget/InlineWidgetView.swift
@@ -6,8 +6,15 @@ struct InlineWidgetView: View {
     let entry: PrayerEntry
 
     var body: some View {
+        let labeledName = displayedPrayerName(
+            entry.nextPrayerName,
+            prayerTime: entry.nextPrayerTime,
+            referenceDate: entry.date,
+            fastingActive: entry.fastingActive,
+            fastingTriggerRaw: entry.fastingTriggerRaw
+        )
         Label {
-            Text("\(entry.nextPrayerName) at \(entry.nextPrayerTime.formatted(.dateTime.hour().minute()))")
+            Text("\(labeledName) at \(entry.nextPrayerTime.formatted(.dateTime.hour().minute()))")
         } icon: {
             Image(systemName: "clock")
         }

--- a/IqamahWidget/IqamahWidget.swift
+++ b/IqamahWidget/IqamahWidget.swift
@@ -13,6 +13,9 @@ struct PrayerEntry: TimelineEntry {
     let todaysPrayers: [(name: String, time: Date)] // excludes Sunrise
     let hijriDateString: String // "" in stub entries
     let sunriseTime: Date? // nil in stub entries
+    // AC-0370: Fasting Mode state for the moment this entry becomes active.
+    let fastingActive: Bool
+    let fastingTriggerRaw: String?
 
     var countdown: String {
         let interval = nextPrayerTime.timeIntervalSince(date)
@@ -41,7 +44,9 @@ struct PrayerTimelineProvider: TimelineProvider {
                 ("Isha", Date().addingTimeInterval(25200)),
             ],
             hijriDateString: "9 Dhu al-Hijjah 1447",
-            sunriseTime: Date().addingTimeInterval(-5400)
+            sunriseTime: Date().addingTimeInterval(-5400),
+            fastingActive: false,
+            fastingTriggerRaw: nil
         )
     }
 
@@ -86,7 +91,7 @@ struct PrayerTimelineProvider: TimelineProvider {
         else {
             return PrayerEntry(date: date, nextPrayerName: "—", nextPrayerTime: date,
                                cityName: "—", methodName: "", todaysPrayers: [], hijriDateString: "",
-                               sunriseTime: nil)
+                               sunriseTime: nil, fastingActive: false, fastingTriggerRaw: nil)
         }
 
         let calc = PrayerCalculator(
@@ -106,6 +111,15 @@ struct PrayerTimelineProvider: TimelineProvider {
             .filter { $0.name != "Sunrise" } ?? []
         let sunriseTime: Date? = todayTimes?.prayers.first { $0.name == "Sunrise" }?.time
 
+        // AC-0370: evaluate Fasting Mode state once per entry date.
+        let fastingState = FastingModeEngine.evaluate(
+            for: date,
+            settings: settings.fastingModeSettings,
+            calculationMethod: settings.calculationMethod,
+            hijriCalendar: Calendar(identifier: .islamicUmmAlQura),
+            timezone: timezone
+        )
+
         // Find next upcoming prayer (today or tomorrow if all past)
         for dayOffset in 0 ... 1 {
             guard let day = Calendar.current.date(byAdding: .day, value: dayOffset, to: date),
@@ -120,7 +134,9 @@ struct PrayerTimelineProvider: TimelineProvider {
                     methodName: methodName,
                     todaysPrayers: todaysPrayers,
                     hijriDateString: hijri,
-                    sunriseTime: sunriseTime
+                    sunriseTime: sunriseTime,
+                    fastingActive: fastingState.isActive,
+                    fastingTriggerRaw: fastingState.trigger?.rawValue
                 )
             }
         }
@@ -128,8 +144,40 @@ struct PrayerTimelineProvider: TimelineProvider {
         return PrayerEntry(date: date, nextPrayerName: "—", nextPrayerTime: date,
                            cityName: cityName, methodName: methodName,
                            todaysPrayers: todaysPrayers, hijriDateString: hijri,
-                           sunriseTime: sunriseTime)
+                           sunriseTime: sunriseTime,
+                           fastingActive: fastingState.isActive,
+                           fastingTriggerRaw: fastingState.trigger?.rawValue)
     }
+}
+
+// MARK: - Fasting Mode relabel helper (AC-0370)
+
+//
+// Widgets only have row name strings; we re-derive the relabel using the
+// engine's contract — Fajr→Suhoor / Maghrib→Iftar within a 2h window when
+// `fastingActive` is true.
+private let widgetRelabelWindow: TimeInterval = 2 * 60 * 60
+
+func displayedPrayerName(
+    _ prayerName: String,
+    prayerTime: Date,
+    referenceDate: Date,
+    fastingActive: Bool,
+    fastingTriggerRaw: String?
+) -> String {
+    guard fastingActive, let trigger = fastingTriggerRaw, !trigger.isEmpty else {
+        return prayerName
+    }
+    let newLabel: String
+    switch prayerName {
+    case "Fajr": newLabel = "Suhoor"
+    case "Maghrib": newLabel = "Iftar"
+    default: return prayerName
+    }
+    let secondsUntil = prayerTime.timeIntervalSince(referenceDate)
+    guard (0 ... widgetRelabelWindow).contains(secondsUntil) else { return prayerName }
+    let glyph = trigger == "autoRamadan" ? "🌙" : "🕗"
+    return "\(glyph) \(newLabel)"
 }
 
 // MARK: - Widget views
@@ -168,8 +216,14 @@ struct IqamahWidgetView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
             Spacer()
-            Text(entry.nextPrayerName)
-                .font(.title3.bold())
+            Text(displayedPrayerName(
+                entry.nextPrayerName,
+                prayerTime: entry.nextPrayerTime,
+                referenceDate: entry.date,
+                fastingActive: entry.fastingActive,
+                fastingTriggerRaw: entry.fastingTriggerRaw
+            ))
+            .font(.title3.bold())
             Text(entry.nextPrayerTime, style: .relative)
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
@@ -234,8 +288,15 @@ struct IqamahWidgetView: View {
                 ForEach(prayers, id: \.name) { prayer in
                     let isNext = prayer.name == entry.nextPrayerName
                     let isPast = prayer.time < entry.date
+                    let relabeled = displayedPrayerName(
+                        prayer.name,
+                        prayerTime: prayer.time,
+                        referenceDate: entry.date,
+                        fastingActive: entry.fastingActive,
+                        fastingTriggerRaw: entry.fastingTriggerRaw
+                    )
                     VStack(spacing: 2) {
-                        Text(prayer.name == "Dhuhr" ? "Zuhr" : prayer.name)
+                        Text(relabeled == prayer.name && prayer.name == "Dhuhr" ? "Zuhr" : relabeled)
                             .font(.system(size: 9, weight: .semibold))
                             .foregroundStyle(isNext ? gold : .secondary)
                         Text(timeFmt.string(from: prayer.time))
@@ -257,8 +318,14 @@ struct IqamahWidgetView: View {
 
     private var lockScreenView: some View {
         HStack {
-            Text(entry.nextPrayerName)
-                .font(.headline)
+            Text(displayedPrayerName(
+                entry.nextPrayerName,
+                prayerTime: entry.nextPrayerTime,
+                referenceDate: entry.date,
+                fastingActive: entry.fastingActive,
+                fastingTriggerRaw: entry.fastingTriggerRaw
+            ))
+            .font(.headline)
             Spacer()
             Text(entry.nextPrayerTime, style: .relative)
                 .font(.caption.monospacedDigit())

--- a/IqamahWidget/LargeWidgetView.swift
+++ b/IqamahWidget/LargeWidgetView.swift
@@ -34,9 +34,15 @@ struct LargeWidgetView: View {
                 let isNext = prayer.name == entry.nextPrayerName
                 let isPast = prayer.time < Date()
                 HStack {
-                    Text(prayer.name)
-                        .font(.system(size: 14, weight: isNext ? .bold : .regular))
-                        .foregroundStyle(isNext ? gold : .primary)
+                    Text(displayedPrayerName(
+                        prayer.name,
+                        prayerTime: prayer.time,
+                        referenceDate: entry.date,
+                        fastingActive: entry.fastingActive,
+                        fastingTriggerRaw: entry.fastingTriggerRaw
+                    ))
+                    .font(.system(size: 14, weight: isNext ? .bold : .regular))
+                    .foregroundStyle(isNext ? gold : .primary)
                     Spacer()
                     Text(prayer.time, style: .time)
                         .font(.system(size: 14, weight: isNext ? .bold : .regular).monospacedDigit())

--- a/IqamahWidget/macOSLargeWidgetView.swift
+++ b/IqamahWidget/macOSLargeWidgetView.swift
@@ -43,9 +43,15 @@
                         if isNext {
                             Circle().fill(gold).frame(width: 5, height: 5)
                         }
-                        Text(prayer.name)
-                            .font(.system(size: 13, weight: isNext ? .bold : .regular))
-                            .foregroundStyle(isNext ? gold : .primary)
+                        Text(displayedPrayerName(
+                            prayer.name,
+                            prayerTime: prayer.time,
+                            referenceDate: entry.date,
+                            fastingActive: entry.fastingActive,
+                            fastingTriggerRaw: entry.fastingTriggerRaw
+                        ))
+                        .font(.system(size: 13, weight: isNext ? .bold : .regular))
+                        .foregroundStyle(isNext ? gold : .primary)
                         Spacer()
                         Text(prayer.time, style: .time)
                             .font(.system(size: 13, weight: isNext ? .bold : .regular).monospacedDigit())

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		LA000000000000000000011 /* PrayerLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA000000000000000000011R /* PrayerLiveActivityView.swift */; };
 		LA000000000000000000021 /* IqamahLiveActivity.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = LA000000000000000000005 /* IqamahLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		MB000000000000000000BB02 /* MenuBarPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MB000000000000000000BB01 /* MenuBarPopoverView.swift */; };
+		FB000000000000000000001 /* FastingBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000000000000000000001R /* FastingBanner.swift */; };
+		FB000000000000000000002 /* FastingBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000000000000000000001R /* FastingBanner.swift */; };
 		MW00000000000000000050 /* IqamahWidgetMac.appex in Embed Mac Widget Extension */ = {isa = PBXBuildFile; fileRef = MW00000000000000000002 /* IqamahWidgetMac.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		PI000000000000000000BB01 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = PI000000000000000000AA01 /* PrivacyInfo.xcprivacy */; };
 		SH00000000000000000001A /* HilalShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = SH00000000000000000000A /* HilalShareSheet.swift */; };
@@ -305,6 +307,7 @@
 		LA000000000000000000010R /* PrayerActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerActivityAttributes.swift; sourceTree = "<group>"; };
 		LA000000000000000000011R /* PrayerLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerLiveActivityView.swift; sourceTree = "<group>"; };
 		MB000000000000000000BB01 /* MenuBarPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarPopoverView.swift; sourceTree = "<group>"; };
+		FB000000000000000000001R /* FastingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastingBanner.swift; sourceTree = "<group>"; };
 		MW00000000000000000002 /* IqamahWidgetMac.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = IqamahWidgetMac.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		MW00000000000000000003 /* InfoMac.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = InfoMac.plist; sourceTree = "<group>"; };
 		MW00000000000000000004 /* IqamahWidgetMac.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IqamahWidgetMac.entitlements; sourceTree = "<group>"; };
@@ -577,6 +580,7 @@
 				EE0000000000000000004003 /* IqamahBackground.swift */,
 				EE0000000000000000006002 /* PrayerTimesComponents.swift */,
 				HW000000000000000000020 /* HilalWatch */,
+				FB000000000000000000050 /* Shared */,
 				944B0D982F635A0500EC6A01 /* TestsAdditionalTests.swift */,
 				944B0D9A2F635AC100EC6A01 /* DocsFINAL_SESSION_SUMMARY.md */,
 			);
@@ -611,6 +615,14 @@
 				EE0000000000000000003003 /* Color+App.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		FB000000000000000000050 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				FB000000000000000000001R /* FastingBanner.swift */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		HW000000000000000000020 /* HilalWatch */ = {
@@ -1141,6 +1153,7 @@
 				BN000000000000000000BB01 /* AdhaanBannerView.swift in Sources */,
 				AB000000000000000000BB01 /* AboutView.swift in Sources */,
 				MB000000000000000000BB02 /* MenuBarPopoverView.swift in Sources */,
+				FB000000000000000000001 /* FastingBanner.swift in Sources */,
 				BN000000000000000000BB02 /* AdhaanBannerController.swift in Sources */,
 				AA0000000000000000000008 /* LocationSetupView.swift in Sources */,
 				AA0000000000000000000009 /* CalculationMethodView.swift in Sources */,
@@ -1237,6 +1250,7 @@
 				AM00000000000000000000A /* PrayerActivityAttributes.swift in Sources */,
 				HC000000000000000000002 /* PrayerHeroCard.swift in Sources */,
 				HC000000000000000000004 /* PrayerRowMobileView.swift in Sources */,
+				FB000000000000000000002 /* FastingBanner.swift in Sources */,
 				iOS0000000000000000000002 /* iOSRootView.swift in Sources */,
 				iOS0000000000000000000003 /* PrayerTimesView.swift in Sources */,
 				iOS0000000000000000000004 /* LocationSetupView.swift in Sources */,

--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -197,7 +197,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
 
         let formatter = PrayerTimes.timeFormatter(for: timezone, use24Hour: settings.use24HourTime)
-        let displayText = "\(next.name) \(formatter.string(from: next.time))"
+        let fastingState = FastingModeEngine.evaluate(
+            for: now,
+            settings: settings.fastingModeSettings,
+            calculationMethod: settings.calculationMethod,
+            hijriCalendar: Calendar(identifier: .islamicUmmAlQura),
+            timezone: timezone
+        )
+        let labeledName = FastingLabelFormatter.relabel(
+            prayerName: next.name,
+            prayerTime: next.time,
+            currentTime: now,
+            state: fastingState
+        )
+        let displayText = "\(labeledName) \(formatter.string(from: next.time))"
         let minutesUntil = Int(next.time.timeIntervalSince(now) / 60)
 
         let textColor: NSColor = minutesUntil < 10 ? .systemRed : .labelColor

--- a/iqamah/Views/MenuBarPopoverView.swift
+++ b/iqamah/Views/MenuBarPopoverView.swift
@@ -22,6 +22,7 @@ struct MenuBarPopoverView: View {
         VStack(spacing: 0) {
             popoverHeader
             datebar
+            fastingBanner
             columnHeaders
             prayerList
             popoverFooter
@@ -113,6 +114,45 @@ struct MenuBarPopoverView: View {
             .padding(.vertical, 5)
             .background(Color.primary.opacity(0.03))
             .overlay(alignment: .bottom) { Divider().opacity(0.5) }
+    }
+
+    // MARK: Fasting banner (AC-0368)
+
+    /// Today's PrayerTimes, recomputed each body pass. Cheap enough — pure math.
+    private var todaysPrayerTimes: PrayerTimes? {
+        guard let city = settings.loadCity(),
+              let tz = TimeZone(identifier: city.timezone) else { return nil }
+        let calc = PrayerCalculator(
+            coordinate: city.coordinate,
+            timezone: tz,
+            method: settings.calculationMethod,
+            asrMethod: settings.asrMethod
+        )
+        return try? calc.calculate(for: Date())
+    }
+
+    @ViewBuilder
+    private var fastingBanner: some View {
+        let timezone = TimeZone(identifier: settings.activeTimezoneIdentifier) ?? .current
+        let fastingState = FastingModeEngine.evaluate(
+            for: Date(),
+            settings: settings.fastingModeSettings,
+            calculationMethod: settings.calculationMethod,
+            hijriCalendar: Calendar(identifier: .islamicUmmAlQura),
+            timezone: timezone
+        )
+        if fastingState.isActive || fastingState.prohibition != nil {
+            let times = todaysPrayerTimes
+            FastingBanner(
+                state: fastingState,
+                fajrTime: times?.fajr,
+                maghribTime: times?.maghrib,
+                isShiaMethod: settings.calculationMethod.isShiaMethod
+            )
+            .padding(.horizontal, 14)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
+        }
     }
 
     // MARK: Column headers

--- a/iqamah/Views/PrayerTimesView.swift
+++ b/iqamah/Views/PrayerTimesView.swift
@@ -76,7 +76,11 @@ struct PrayerTimesView: View {
                             moonPhaseSubtitle: moonPhaseSubtitle,
                             isHilalWatchEvening: isHilalWatchEvening,
                             nextPrayerTime: nextPrayerTime,
-                            onHilalWatch: openHilalWatch
+                            onHilalWatch: openHilalWatch,
+                            fastingPrayerTimes: times,
+                            fastingSettings: SettingsManager.shared.fastingModeSettings,
+                            fastingCalculationMethod: calculationMethod,
+                            fastingTimezone: tz
                         )
                         Text(currentDate.formattedGregorianDate())
                             .font(.subheadline.bold())

--- a/iqamah/Views/Shared/FastingBanner.swift
+++ b/iqamah/Views/Shared/FastingBanner.swift
@@ -1,0 +1,121 @@
+import IqamahCore
+import SwiftUI
+
+/// Shared dual-countdown banner for Fasting Mode.
+/// Renders either: active state (Suhoor ends + Iftar at), or prohibition message.
+/// Callers must gate on `state.isActive || state.prohibition != nil` before rendering.
+///
+/// Used by macOS popover (Task 11) and iOS hero card (Task 12).
+/// AC-0366, AC-0367.
+public struct FastingBanner: View {
+    let state: FastingDayState
+    let fajrTime: Date?
+    let maghribTime: Date?
+    let isShiaMethod: Bool
+
+    public init(state: FastingDayState, fajrTime: Date?, maghribTime: Date?, isShiaMethod: Bool) {
+        self.state = state
+        self.fajrTime = fajrTime
+        self.maghribTime = maghribTime
+        self.isShiaMethod = isShiaMethod
+    }
+
+    public var body: some View {
+        Group {
+            if let prohibition = state.prohibition {
+                prohibitionBanner(prohibition)
+            } else if state.isActive {
+                activeBanner
+            } else {
+                EmptyView() // caller should not have rendered us
+            }
+        }
+    }
+
+    private var activeBanner: some View {
+        let isRamadan = state.trigger == .autoRamadan
+        let gradient: LinearGradient = isRamadan
+            ? LinearGradient(
+                colors: [
+                    Color(red: 0.16, green: 0.10, blue: 0.23),
+                    Color(red: 0.10, green: 0.16, blue: 0.23),
+                ],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+            : LinearGradient(
+                colors: [
+                    Color(red: 0.10, green: 0.23, blue: 0.23),
+                    Color(red: 0.10, green: 0.16, blue: 0.23),
+                ],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+        let glyph = isRamadan ? "🌙" : "🕗"
+        let gold = Color(red: 0.79, green: 0.63, blue: 0.23)
+
+        return HStack(alignment: .center, spacing: 12) {
+            Text(glyph).font(.system(size: 28))
+            VStack(alignment: .leading, spacing: 4) {
+                if let fajr = fajrTime {
+                    HStack {
+                        Text("Suhoor ends")
+                            .font(.caption).fontWeight(.semibold)
+                            .foregroundStyle(gold)
+                        Spacer()
+                        Text(formatted(fajr))
+                            .font(.caption).fontWeight(.medium).monospacedDigit()
+                            .foregroundStyle(.white)
+                    }
+                }
+                if let maghrib = maghribTime {
+                    HStack {
+                        Text("Iftar at")
+                            .font(.caption).fontWeight(.semibold)
+                            .foregroundStyle(gold)
+                        Spacer()
+                        Text(formatted(maghrib))
+                            .font(.caption).fontWeight(.medium).monospacedDigit()
+                            .foregroundStyle(.white)
+                    }
+                }
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(gradient)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(gold.opacity(0.3), lineWidth: 1)
+                )
+        )
+    }
+
+    private func prohibitionBanner(_ prohibition: ProhibitedDay) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            Text("⚠️").font(.system(size: 24))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(prohibition.displayName)
+                    .font(.subheadline).fontWeight(.semibold)
+                    .foregroundStyle(.white)
+                Text("Fasting is forbidden today")
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+            Spacer()
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(LinearGradient(
+                    colors: [Color(white: 0.16), Color(white: 0.10)],
+                    startPoint: .topLeading, endPoint: .bottomTrailing
+                ))
+        )
+    }
+
+    private func formatted(_ date: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.timeStyle = .short
+        return fmt.string(from: date)
+    }
+}

--- a/iqamah/iOS/PrayerActivityManager.swift
+++ b/iqamah/iOS/PrayerActivityManager.swift
@@ -120,12 +120,24 @@
 
             guard let next = nextPrayer else { return nil }
 
+            // AC-0370: include today's Fasting Mode state so the Live Activity
+            // can render the Suhoor/Iftar relabel within the 2h window.
+            let fastingState = FastingModeEngine.evaluate(
+                for: now,
+                settings: settings.fastingModeSettings,
+                calculationMethod: settings.calculationMethod,
+                hijriCalendar: Calendar(identifier: .islamicUmmAlQura),
+                timezone: timezone
+            )
+
             return PrayerActivityAttributes.ContentState(
                 nextPrayerName: next.name,
                 nextPrayerTime: next.time,
                 followingPrayerName: followingPrayer?.name ?? "",
                 moonPhase: moonPhase(for: now),
-                hijriDateString: hijriDateString(for: now, offset: settings.hijriDayOffset)
+                hijriDateString: hijriDateString(for: now, offset: settings.hijriDayOffset),
+                fastingActive: fastingState.isActive,
+                fastingTriggerRaw: fastingState.trigger?.rawValue
             )
         }
     }

--- a/iqamah/iOS/PrayerHeroCard.swift
+++ b/iqamah/iOS/PrayerHeroCard.swift
@@ -5,6 +5,9 @@
     /// Hero card shown above the prayer list on iPhone and iPad portrait.
     /// Displays the current moon phase, Hijri date, countdown to next prayer,
     /// and a Hilal Watch entry button.
+    ///
+    /// When Fasting Mode is active (or today is hard-prohibited), a `FastingBanner`
+    /// is rendered above the hero block. AC-0369 (iOS portion).
     struct PrayerHeroCard: View {
         let moonPhase: Double
         let hijriDateLabel: String
@@ -12,11 +15,71 @@
         let isHilalWatchEvening: Bool
         let nextPrayerTime: Date?
         let onHilalWatch: () -> Void
+        // Fasting Mode inputs (optional — caller passes today's PrayerTimes + settings).
+        let fastingPrayerTimes: PrayerTimes?
+        let fastingSettings: FastingModeSettings?
+        let fastingCalculationMethod: CalculationMethod?
+        let fastingTimezone: TimeZone?
+
+        init(
+            moonPhase: Double,
+            hijriDateLabel: String,
+            moonPhaseSubtitle: String,
+            isHilalWatchEvening: Bool,
+            nextPrayerTime: Date?,
+            onHilalWatch: @escaping () -> Void,
+            fastingPrayerTimes: PrayerTimes? = nil,
+            fastingSettings: FastingModeSettings? = nil,
+            fastingCalculationMethod: CalculationMethod? = nil,
+            fastingTimezone: TimeZone? = nil
+        ) {
+            self.moonPhase = moonPhase
+            self.hijriDateLabel = hijriDateLabel
+            self.moonPhaseSubtitle = moonPhaseSubtitle
+            self.isHilalWatchEvening = isHilalWatchEvening
+            self.nextPrayerTime = nextPrayerTime
+            self.onHilalWatch = onHilalWatch
+            self.fastingPrayerTimes = fastingPrayerTimes
+            self.fastingSettings = fastingSettings
+            self.fastingCalculationMethod = fastingCalculationMethod
+            self.fastingTimezone = fastingTimezone
+        }
 
         @Environment(\.colorScheme) private var colorScheme
         private var gold: Color { colorScheme == .dark ? .appGold : .appGoldDark }
 
+        /// AC-0369 (iOS): evaluate today's Fasting Mode state when caller provided inputs.
+        private var fastingState: FastingDayState? {
+            guard let settings = fastingSettings,
+                  let method = fastingCalculationMethod,
+                  let tz = fastingTimezone else { return nil }
+            return FastingModeEngine.evaluate(
+                for: Date(),
+                settings: settings,
+                calculationMethod: method,
+                hijriCalendar: Calendar(identifier: .islamicUmmAlQura),
+                timezone: tz
+            )
+        }
+
         var body: some View {
+            VStack(spacing: 0) {
+                if let state = fastingState,
+                   state.isActive || state.prohibition != nil {
+                    FastingBanner(
+                        state: state,
+                        fajrTime: fastingPrayerTimes?.fajr,
+                        maghribTime: fastingPrayerTimes?.maghrib,
+                        isShiaMethod: fastingCalculationMethod?.isShiaMethod ?? false
+                    )
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                }
+                heroRow
+            }
+        }
+
+        private var heroRow: some View {
             HStack(alignment: .center, spacing: 12) {
                 MoonPhaseView(phase: moonPhase, size: 48)
                     .accessibilityHidden(true)

--- a/iqamah/iOS/PrayerRowMobileView.swift
+++ b/iqamah/iOS/PrayerRowMobileView.swift
@@ -19,8 +19,29 @@
         let onToggleMute: () -> Void
 
         @Environment(\.colorScheme) private var colorScheme
+        @ObservedObject private var settings = SettingsManager.shared
         private var gold: Color { colorScheme == .dark ? .appGold : .appGoldDark }
         private var isSunrise: Bool { name == "Sunrise" }
+
+        /// Apply Fasting Mode relabel (Fajr→Suhoor, Maghrib→Iftar with glyph)
+        /// when state.isActive and the prayer is within the 2h window.
+        /// AC-0369 (iOS portion).
+        private var displayedName: String {
+            let timezone = TimeZone(identifier: settings.activeTimezoneIdentifier) ?? .current
+            let state = FastingModeEngine.evaluate(
+                for: Date(),
+                settings: settings.fastingModeSettings,
+                calculationMethod: settings.calculationMethod,
+                hijriCalendar: Calendar(identifier: .islamicUmmAlQura),
+                timezone: timezone
+            )
+            return FastingLabelFormatter.relabel(
+                prayerName: name,
+                prayerTime: time,
+                currentTime: Date(),
+                state: state
+            )
+        }
 
         var body: some View {
             VStack(spacing: 0) {
@@ -54,7 +75,7 @@
 
                     // Prayer name
                     VStack(alignment: .leading, spacing: 1) {
-                        Text(name)
+                        Text(displayedName)
                             .font(isNext ? .body.bold() : .body)
                             .foregroundStyle(isNext ? gold : .primary)
                         if isNext {


### PR DESCRIPTION
## Summary

Second PR in the Fasting Mode rollout (EPIC-0017). Builds on the foundation merged in PR #132 (Tasks 1–9) to wire the engine through every UI surface — macOS, iOS, watchOS, widgets, and Live Activity.

- **Task 10 (AC-0366, AC-0367):** `FastingBanner` — shared SwiftUI view. Multi-target (iqamah + iqamah-iOS). Active variant: purple+🌙 (Ramadan) or teal+🕗 (Nawafil) with Suhoor-ends + Iftar-at rows. Prohibition variant: grey+⚠️ with the day name.
- **Task 11 (AC-0368):** macOS menu bar countdown applies `FastingLabelFormatter.relabel` within the 2h window; popover renders `FastingBanner` above the prayer list when fasting/prohibited.
- **Task 12 (AC-0369 iOS):** `PrayerHeroCard` renders the banner above the hero row when active/prohibited. `PrayerRowMobileView` applies the relabel within the 2h window.
- **Task 13 (AC-0369 watchOS):** Watch prayer row applies the relabel. Banner skipped — limited screen real estate, per plan.
- **Task 14 (AC-0370):** `PrayerActivityAttributes.ContentState` gains two optional fields (`fastingActive`, `fastingTriggerRaw`) with a forward-compatible decoder so v1.5 in-flight activities decode cleanly under v1.6. iOS widget `TimelineEntry` and the watch widget `PrayerEntry` mirror the same fields. Live Activity, iOS widget, macOS widget, and watch-widget views apply a local relabel helper (mirrors `FastingLabelFormatter.relabel`).

## Notable design choices

- **`PrayerHeroCard` receives `fastingSettings/fastingCalculationMethod/fastingTimezone` rather than a pre-computed `FastingDayState`.** Moves the engine call inside the hero card to keep `PrayerTimesView.swift` under the 660-line file-length limit. The hero card's existing call sites all live in the parent (`PrayerTimesView`) so the wider API surface is justified.
- **Live Activity relabel helper is inlined as a private file-scope function in `PrayerLiveActivityView.swift`** rather than importing IqamahCore. The Live Activity extension is intentionally not linked to IqamahCore to keep the appex binary small (matches the existing pattern — `activityGold`, `CrescentView` are duplicated for the same reason). Widget targets DO link IqamahCore, so the engine is called directly in the timeline provider; the widget views' relabel helper is a free function so the same logic isn't duplicated across `LargeWidgetView`/`macOSLargeWidgetView`/`InlineWidgetView`.
- **`PrayerActivityAttributes.ContentState` keeps a custom `init(from:)` decoder** instead of relying on Swift's synthesized Codable. Synthesized Codable throws `keyNotFound` for absent fields — `decodeIfPresent` keeps v1.5 in-flight activities decoding cleanly when the user upgrades mid-prayer-window.
- **No version/build bump.** Staying on 1.6.0 / build 15 from PR #132.

## Build & test status

- `cd Packages/IqamahCore && swift test` — **251 tests passing, 44 suites**, no regressions.
- `xcodebuild ... -scheme iqamah` — BUILD SUCCEEDED.
- `xcodebuild ... -scheme iqamah-iOS -destination 'generic/platform=iOS'` — BUILD SUCCEEDED (includes IqamahLiveActivity + IqamahWidget extensions).
- `xcodebuild ... -scheme IqamahWatch -destination 'generic/platform=watchOS'` — BUILD SUCCEEDED (includes IqamahWatchWidget).
- `swiftformat --lint --strict iqamah/` — clean.
- `swiftlint lint --strict` — clean.

## Test plan

- [ ] Enable Fasting Mode in Settings; toggle weekly days to include today. Banner appears in macOS popover within ~60s.
- [ ] Within 2h of Fajr: menu bar countdown shows "🕗 Suhoor 04:35" (or 🌙 in Ramadan).
- [ ] Within 2h of Maghrib: menu bar countdown shows "🕗 Iftar 19:42".
- [ ] iOS hero card shows the banner above the prayer countdown; PrayerRowMobileView name flips to Suhoor/Iftar within the 2h window.
- [ ] watchOS prayer tab row name flips within the 2h window (no banner, per spec).
- [ ] iOS widget (small/medium/large/lock-screen) shows the relabeled name when within 2h.
- [ ] macOS widget (Notification Center large) shows the relabeled name when within 2h.
- [ ] Watch widget complications (Rectangular, Inline) show the relabeled name.
- [ ] Live Activity Dynamic Island (compactLeading + expanded trailing) + lock screen view show the relabeled name.
- [ ] Eid al-Fitr (1 Shawwal) / Eid al-Adha (10 Dhul-Hijjah) / Tashriq (11–13 Dhul-Hijjah): prohibition banner renders; no relabel applied.

## Out of scope (deferred to Task 15+)

- Settings UI (`FastingModeSection`) — separate task in the plan, not in this PR.
- Notification scheduling integration — already wired in Foundation PR; no changes here.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>