### PR TITLE
feat(ui): Fasting Mode settings UI (Tasks 15–16 of EPIC-0017)

### DIFF
--- a/IqamahWatch/SettingsTab.swift
+++ b/IqamahWatch/SettingsTab.swift
@@ -74,6 +74,13 @@ struct SettingsTab: View {
                 Toggle("Prayer haptics", isOn: $settings.hilalNotificationEnabled)
             }
 
+            Section("Fasting Mode") {
+                Toggle("Enable", isOn: $settings.fastingModeSettings.enabled)
+                Text("Configure triggers + reminders on iPhone or Mac")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Display") {
                 Toggle("24-hour time", isOn: $settings.use24HourTime)
             }

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		MB000000000000000000BB02 /* MenuBarPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MB000000000000000000BB01 /* MenuBarPopoverView.swift */; };
 		FB000000000000000000001 /* FastingBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000000000000000000001R /* FastingBanner.swift */; };
 		FB000000000000000000002 /* FastingBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000000000000000000001R /* FastingBanner.swift */; };
+		FB000000000000000000003 /* FastingModeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000000000000000000003R /* FastingModeSection.swift */; };
+		FB000000000000000000004 /* FastingModeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000000000000000000003R /* FastingModeSection.swift */; };
 		MW00000000000000000050 /* IqamahWidgetMac.appex in Embed Mac Widget Extension */ = {isa = PBXBuildFile; fileRef = MW00000000000000000002 /* IqamahWidgetMac.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		PI000000000000000000BB01 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = PI000000000000000000AA01 /* PrivacyInfo.xcprivacy */; };
 		SH00000000000000000001A /* HilalShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = SH00000000000000000000A /* HilalShareSheet.swift */; };
@@ -308,6 +310,7 @@
 		LA000000000000000000011R /* PrayerLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerLiveActivityView.swift; sourceTree = "<group>"; };
 		MB000000000000000000BB01 /* MenuBarPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarPopoverView.swift; sourceTree = "<group>"; };
 		FB000000000000000000001R /* FastingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastingBanner.swift; sourceTree = "<group>"; };
+		FB000000000000000000003R /* FastingModeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastingModeSection.swift; sourceTree = "<group>"; };
 		MW00000000000000000002 /* IqamahWidgetMac.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = IqamahWidgetMac.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		MW00000000000000000003 /* InfoMac.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = InfoMac.plist; sourceTree = "<group>"; };
 		MW00000000000000000004 /* IqamahWidgetMac.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IqamahWidgetMac.entitlements; sourceTree = "<group>"; };
@@ -621,6 +624,7 @@
 			isa = PBXGroup;
 			children = (
 				FB000000000000000000001R /* FastingBanner.swift */,
+				FB000000000000000000003R /* FastingModeSection.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1154,6 +1158,7 @@
 				AB000000000000000000BB01 /* AboutView.swift in Sources */,
 				MB000000000000000000BB02 /* MenuBarPopoverView.swift in Sources */,
 				FB000000000000000000001 /* FastingBanner.swift in Sources */,
+				FB000000000000000000003 /* FastingModeSection.swift in Sources */,
 				BN000000000000000000BB02 /* AdhaanBannerController.swift in Sources */,
 				AA0000000000000000000008 /* LocationSetupView.swift in Sources */,
 				AA0000000000000000000009 /* CalculationMethodView.swift in Sources */,
@@ -1251,6 +1256,7 @@
 				HC000000000000000000002 /* PrayerHeroCard.swift in Sources */,
 				HC000000000000000000004 /* PrayerRowMobileView.swift in Sources */,
 				FB000000000000000000002 /* FastingBanner.swift in Sources */,
+				FB000000000000000000004 /* FastingModeSection.swift in Sources */,
 				iOS0000000000000000000002 /* iOSRootView.swift in Sources */,
 				iOS0000000000000000000003 /* PrayerTimesView.swift in Sources */,
 				iOS0000000000000000000004 /* LocationSetupView.swift in Sources */,

--- a/iqamah/Views/SettingsSheetView.swift
+++ b/iqamah/Views/SettingsSheetView.swift
@@ -356,6 +356,7 @@ struct SettingsSheetView: View {
             Section { locationSection } header: { Label("Location", systemImage: "location.fill") }
             Section { calculationSection } header: { Label("Calculation", systemImage: "function") }
             Section { displaySection } header: { Label("Display", systemImage: "display") }
+            FastingModeSection(settings: SettingsManager.shared)
             Section { HilalWatchSettingsSection() } header: { Label("Hilal Watch", systemImage: "moon.haze.fill") }
             Section {
                 adjustmentsSection

--- a/iqamah/Views/Shared/FastingModeSection.swift
+++ b/iqamah/Views/Shared/FastingModeSection.swift
@@ -1,0 +1,166 @@
+import IqamahCore
+import SwiftUI
+
+/// Settings section for Fasting Mode. Renders the master toggle and, when on,
+/// all sub-controls. Adapts visibility/labels based on
+/// `settings.calculationMethod.isShiaMethod` (AC-0371 / AC-0372 / AC-0373 / AC-0374).
+///
+/// Extracted to its own file so `SettingsSheetView.swift` stays under the
+/// SwiftLint `file_length` limit.
+public struct FastingModeSection: View {
+    @ObservedObject var settings: SettingsManager
+
+    public init(settings: SettingsManager) {
+        self.settings = settings
+    }
+
+    public var body: some View {
+        Section {
+            Toggle("Enable Fasting Mode", isOn: $settings.fastingModeSettings.enabled)
+
+            if settings.fastingModeSettings.enabled {
+                activationGroup
+                remindersGroup
+            }
+        } header: {
+            Label("Fasting Mode", systemImage: "moon.stars.fill")
+        }
+    }
+
+    // MARK: - Activation
+
+    @ViewBuilder private var activationGroup: some View {
+        Toggle("Auto-enable during Ramadan", isOn: $settings.fastingModeSettings.autoRamadan)
+
+        weeklyPicker
+
+        if settings.fastingModeSettings.hasFridayAloneWarning {
+            Label(
+                "Friday alone is discouraged. Consider adding Thursday or Saturday.",
+                systemImage: "exclamationmark.triangle.fill"
+            )
+            .font(.caption)
+            .foregroundStyle(.orange)
+        }
+        if settings.fastingModeSettings.hasSaturdayAloneWarning {
+            Label(
+                "Saturday alone is discouraged. Consider adding Friday.",
+                systemImage: "exclamationmark.triangle.fill"
+            )
+            .font(.caption)
+            .foregroundStyle(.orange)
+        }
+
+        Toggle("Monthly: Ayyam al-Beed (13–15)", isOn: $settings.fastingModeSettings.ayyamAlBeed)
+        Toggle("Annual: 6 days of Shawwal", isOn: $settings.fastingModeSettings.sixDaysShawwal)
+        Toggle("Annual: Day of Arafah (9 Dhul-Hijjah)", isOn: $settings.fastingModeSettings.dayOfArafah)
+        Toggle("Annual: First 9 of Dhul-Hijjah", isOn: $settings.fastingModeSettings.firstNineDhulHijjah)
+
+        muharramFastRow
+
+        if settings.calculationMethod.isShiaMethod {
+            Toggle("Annual: 15 Sha'ban — Laylat al-Bara'ah", isOn: $settings.fastingModeSettings.midShaban)
+            Toggle("Annual: 27 Rajab — Mab'ath an-Nabi", isOn: $settings.fastingModeSettings.mabath)
+        }
+    }
+
+    private var muharramFastRow: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Toggle(isOn: $settings.fastingModeSettings.muharramFast) {
+                Text(settings.calculationMethod.isShiaMethod
+                    ? "Annual: Tasu'a (9 Muharram)"
+                    : "Annual: Ashura (9+10 Muharram)")
+            }
+            Text(settings.calculationMethod.isShiaMethod
+                ? "Shia tradition: commemoration day"
+                : "Sunni Sunnah fast")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Weekly picker
+
+    /// Calendar weekday convention: 1=Sunday, 2=Monday, ..., 7=Saturday.
+    /// Order respects `Calendar.current.firstWeekday` and uses locale-aware symbols.
+    private var orderedWeekdays: [(day: Int, short: String)] {
+        let cal = Calendar.current
+        let symbols = cal.veryShortWeekdaySymbols // 7 entries, index 0 = Sunday
+        let first = cal.firstWeekday // 1...7
+        return (0 ..< 7).map { offset in
+            let weekday = ((first - 1 + offset) % 7) + 1
+            return (day: weekday, short: symbols[weekday - 1])
+        }
+    }
+
+    private var weeklyPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Weekly schedule").font(.subheadline)
+            HStack(spacing: 6) {
+                ForEach(orderedWeekdays, id: \.day) { wd in
+                    weekdayChip(day: wd.day, label: wd.short)
+                }
+            }
+        }
+    }
+
+    private func weekdayChip(day: Int, label: String) -> some View {
+        let selected = settings.fastingModeSettings.weeklyDays.contains(day)
+        return Button {
+            toggleWeekday(day)
+        } label: {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .frame(minWidth: 32, minHeight: 32)
+                .background(
+                    Circle().fill(selected
+                        ? Color(red: 0.79, green: 0.63, blue: 0.23)
+                        : Color.gray.opacity(0.2))
+                )
+                .foregroundStyle(selected ? Color.white : Color.primary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(label))
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    private func toggleWeekday(_ day: Int) {
+        if settings.fastingModeSettings.weeklyDays.contains(day) {
+            settings.fastingModeSettings.weeklyDays.remove(day)
+        } else {
+            settings.fastingModeSettings.weeklyDays.insert(day)
+        }
+    }
+
+    // MARK: - Reminders
+
+    @ViewBuilder private var remindersGroup: some View {
+        Toggle("Send system notifications", isOn: $settings.fastingModeSettings.notificationsEnabled)
+
+        if settings.fastingModeSettings.notificationsEnabled {
+            Stepper(value: $settings.fastingModeSettings.suhoorLeadMinutes, in: 5 ... 120, step: 5) {
+                Text("Suhoor lead time: \(settings.fastingModeSettings.suhoorLeadMinutes) min")
+            }
+            Stepper(value: $settings.fastingModeSettings.iftarLeadMinutes, in: 5 ... 120, step: 5) {
+                Text("Iftar lead time: \(settings.fastingModeSettings.iftarLeadMinutes) min")
+            }
+            Toggle("Notify night before fasting day", isOn: $settings.fastingModeSettings.dayBeforeEnabled)
+            if settings.fastingModeSettings.dayBeforeEnabled {
+                HStack {
+                    Text("Day-before time")
+                    Spacer()
+                    Stepper(value: $settings.fastingModeSettings.dayBeforeHour, in: 0 ... 23) {
+                        Text(dayBeforeTimeLabel)
+                            .monospacedDigit()
+                    }
+                }
+            }
+        }
+    }
+
+    private var dayBeforeTimeLabel: String {
+        let h = settings.fastingModeSettings.dayBeforeHour
+        let m = settings.fastingModeSettings.dayBeforeMinute
+        return String(format: "%02d:%02d", h, m)
+    }
+}


### PR DESCRIPTION
## Summary

Third PR in the Fasting Mode rollout (EPIC-0017). Builds on the foundation (PR #132) and UI wiring (PR #136) to deliver the configuration surface.

### Task 15 — `FastingModeSection` (AC-0371, AC-0372, AC-0373, AC-0374)
- New `iqamah/Views/Shared/FastingModeSection.swift`, multi-targeted to macOS `iqamah` + `iqamah-iOS`.
- Inserted into `SettingsSheetView` between Display and Hilal Watch sections.
- Master toggle gates all sub-controls. Inside:
  - Auto-enable during Ramadan.
  - Weekly schedule chips — ordered per `Calendar.current.firstWeekday`, labelled with `veryShortWeekdaySymbols` (locale-aware).
  - Friday-alone / Saturday-alone warning labels driven by `FastingModeSettings.hasFridayAloneWarning` / `hasSaturdayAloneWarning`.
  - Ayyam al-Beed, 6 Shawwal, Day of Arafah, First 9 of Dhul-Hijjah toggles.
  - Muharram row: label flips between "Ashura (9+10 Muharram)" / "Tasu'a (9 Muharram)" based on `calculationMethod.isShiaMethod`, with matching caption.
  - Shia-only block (15 Sha'ban, 27 Rajab) shown only when method is `jafari` or `tehran`. Hidden toggles retain stored values via the persisted struct.
  - Reminders: notification toggle, suhoor/iftar lead steppers (5…120, step 5), day-before toggle + hour stepper.

### Task 16 — watch `SettingsTab` entry (AC-0375)
- Added a "Fasting Mode" section with master toggle + "Configure triggers + reminders on iPhone or Mac" hint. Watch syncs settings via KVS.

### Deviations from plan
- Used `Section { … } header: { Label(…) }` to match the styling of neighbouring sections in `SettingsSheetView` (plan showed a bare `Section("Fasting Mode")`).
- Weekday chips are rendered locale-aware (`firstWeekday` + `veryShortWeekdaySymbols`) instead of the plan's hardcoded `M T W Th F S Su`, per the controller brief's emphasis on locale awareness.
- No changes to version (still 1.6.0 / build 15).

## Test plan

- [x] `swift build` in `Packages/IqamahCore` — clean.
- [x] `xcodebuild` macOS `iqamah` scheme — BUILD SUCCEEDED.
- [x] `xcodebuild` `iqamah-iOS` generic iOS — BUILD SUCCEEDED.
- [x] `xcodebuild` `IqamahWatch` generic watchOS — BUILD SUCCEEDED.
- [x] `swiftformat --lint --strict` on touched files — clean.
- [x] `swiftlint --strict` on touched files — 0 violations.
- [x] `plutil -lint` on `project.pbxproj` — OK.
- [ ] Manual smoke (left for reviewer): toggle master off/on, tap Friday alone (warning appears), switch method to Ja'fari (Muharram relabels, 15 Sha'ban + 27 Rajab appear), switch back to MWL (those toggles disappear, values retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>