### PR TITLE
fix(BUG-0069): show detected city in picker + opt-in 25km auto-detect

### DIFF
--- a/IqamahWatch/IqamahWatchApp.swift
+++ b/IqamahWatch/IqamahWatchApp.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct IqamahWatchApp: App {
     @StateObject private var settings = SettingsManager.shared
     @StateObject private var locationSetup = WatchLocationSetup()
+    @StateObject private var moveDetector = WatchMoveDetector()
 
     init() {
         // Pre-seed Toronto / ISNA settings so XCUITests skip location setup (AC-0336, US-0068).
@@ -34,6 +35,27 @@ struct IqamahWatchApp: App {
                 locationSetup.start(settings: settings)
                 WatchSessionManager.shared.activate(settings: settings)
                 WatchNotificationScheduler.shared.requestFastingReschedule()
+                moveDetector.startIfNeeded(settings: settings)
+            }
+            .alert(
+                "Have you moved?",
+                isPresented: Binding(
+                    get: { moveDetector.pendingPayload != nil },
+                    set: { if !$0 { moveDetector.pendingPayload = nil } }
+                ),
+                presenting: moveDetector.pendingPayload
+            ) { payload in
+                Button("Switch") {
+                    moveDetector.applySwitch(payload: payload, settings: settings)
+                }
+                Button("Not now", role: .cancel) {
+                    moveDetector.pendingPayload = nil
+                }
+            } message: { payload in
+                let whereText = payload.detectedLocality.isEmpty
+                    ? "your current location"
+                    : payload.detectedLocality
+                Text("You appear to be in \(whereText), ~\(payload.distanceKmString) from \(payload.savedCityName). Switch?")
             }
             .onChange(of: settings.fastingModeSettings) { _, _ in
                 WatchNotificationScheduler.shared.requestFastingReschedule()
@@ -168,5 +190,81 @@ final class WatchLocationSetup: NSObject, ObservableObject, CLLocationManagerDel
             statusMessage = "Location unavailable — tap to retry"
             isReady = true
         }
+    }
+}
+
+// MARK: - BUG-0069 watch launch-time move detector
+
+@MainActor
+final class WatchMoveDetector: NSObject, ObservableObject, CLLocationManagerDelegate {
+    @Published var pendingPayload: MoveDetectedPayload?
+
+    private let manager = CLLocationManager()
+    private var didStart = false
+    private weak var settingsRef: SettingsManager?
+
+    func startIfNeeded(settings: SettingsManager) {
+        guard !didStart else { return }
+        didStart = true
+        settingsRef = settings
+        guard settings.hasCompletedSetup, settings.autoDetectOnMove else { return }
+        guard settings.loadCity() != nil else { return }
+
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyKilometer
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            manager.requestLocation()
+        default:
+            // Don't badger the user — the main onboarding flow handles permission.
+            return
+        }
+    }
+
+    func applySwitch(payload: MoveDetectedPayload, settings: SettingsManager) {
+        let locality = payload.detectedLocality.isEmpty
+            ? payload.savedCityName
+            : payload.detectedLocality
+        if let newCity = try? City(
+            name: locality,
+            countryCode: settings.loadCity()?.countryCode ?? "US",
+            latitude: payload.detectedCoordinate.latitude,
+            longitude: payload.detectedCoordinate.longitude,
+            timezone: TimeZone.current.identifier
+        ) {
+            settings.saveCity(newCity)
+            settings.locationSource = "gps"
+            settings.saveGPSCoordinates(payload.detectedCoordinate)
+            settings.gpsLocality = payload.detectedLocality
+            settings.gpsDetectedCity = newCity
+        }
+        pendingPayload = nil
+    }
+
+    nonisolated func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let loc = locations.first else { return }
+        Task { @MainActor in
+            guard let settings = settingsRef else { return }
+            let outcome = AutoDetectMoveCheck.evaluate(
+                settings: settings,
+                currentCoordinate: loc.coordinate
+            )
+            guard case let .shouldPrompt(distance, savedName) = outcome else { return }
+            CLGeocoder().reverseGeocodeLocation(loc) { placemarks, _ in
+                let locality = placemarks?.first?.locality ?? placemarks?.first?.name ?? ""
+                Task { @MainActor in
+                    self.pendingPayload = MoveDetectedPayload(
+                        savedCityName: savedName,
+                        detectedCoordinate: loc.coordinate,
+                        distanceMeters: distance,
+                        detectedLocality: locality
+                    )
+                }
+            }
+        }
+    }
+
+    nonisolated func locationManager(_: CLLocationManager, didFailWithError _: Error) {
+        // Silent — this is opportunistic.
     }
 }

--- a/IqamahWatch/SettingsTab.swift
+++ b/IqamahWatch/SettingsTab.swift
@@ -40,6 +40,10 @@ struct SettingsTab: View {
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }
+
+                // BUG-0069
+                Toggle("Auto-detect if I move > 25 km", isOn: $settings.autoDetectOnMove)
+                    .font(.caption2)
             }
 
             Section("Prayer Times") {

--- a/IqamahWatch/SettingsTab.swift
+++ b/IqamahWatch/SettingsTab.swift
@@ -156,12 +156,30 @@ struct WatchCityPicker: View {
 
     var body: some View {
         List {
-            ForEach(filtered) { city in
-                Button(city.name) {
-                    settings.saveCity(city)
-                    settings.locationSource = "manual"
-                    WidgetCenter.shared.reloadAllTimelines()
-                    dismiss()
+            // BUG-0069: surface the GPS-detected city at the top of the watch picker
+            // when its country matches the country the user drilled into.
+            if let gpsCity = SettingsManager.shared.gpsDetectedCity,
+               let firstCity = cities.first,
+               gpsCity.countryCode == firstCity.countryCode {
+                Section("Current Location") {
+                    Button {
+                        settings.saveCity(gpsCity)
+                        settings.locationSource = "gps"
+                        WidgetCenter.shared.reloadAllTimelines()
+                        dismiss()
+                    } label: {
+                        Label(gpsCity.name, systemImage: "location.fill")
+                    }
+                }
+            }
+            Section("All Cities") {
+                ForEach(filtered) { city in
+                    Button(city.name) {
+                        settings.saveCity(city)
+                        settings.locationSource = "manual"
+                        WidgetCenter.shared.reloadAllTimelines()
+                        dismiss()
+                    }
                 }
             }
         }

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/AutoDetectMoveCheck.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/AutoDetectMoveCheck.swift
@@ -1,0 +1,68 @@
+import CoreLocation
+import Foundation
+
+/// BUG-0069: launch-time check that asks whether the user has moved more than
+/// 25 km from their saved city. Pure logic — UI sits on top of it.
+///
+/// Each platform's app entry point calls `evaluate(_:savedCity:)` with the
+/// freshly-resolved GPS coordinate. If the result is `.shouldPrompt`, the
+/// caller surfaces a non-modal alert offering to switch the saved city.
+/// We never auto-switch — the user's manual selection must always win.
+public enum AutoDetectMoveCheck {
+    /// Outcome of evaluating a freshly-resolved GPS coordinate against the saved city.
+    public enum Outcome: Equatable {
+        /// Auto-detect is disabled, the user has not yet completed setup, or no saved city.
+        case skip
+        /// The user is still within `SettingsManager.autoDetectThresholdMeters` of their saved city.
+        case withinThreshold(distanceMeters: CLLocationDistance)
+        /// The user has moved beyond the threshold — caller should present the switch prompt.
+        case shouldPrompt(distanceMeters: CLLocationDistance, savedCityName: String)
+    }
+
+    /// Pure decision function. Caller is responsible for fetching the GPS coordinate
+    /// and presenting any UI.
+    public static func evaluate(
+        settings: SettingsManager,
+        currentCoordinate: CLLocationCoordinate2D
+    ) -> Outcome {
+        guard settings.hasCompletedSetup, settings.autoDetectOnMove else { return .skip }
+        guard let saved = settings.loadCity() else { return .skip }
+        let distance = SettingsManager.distance(from: saved.coordinate, to: currentCoordinate)
+        if distance > SettingsManager.autoDetectThresholdMeters {
+            return .shouldPrompt(distanceMeters: distance, savedCityName: saved.name)
+        }
+        return .withinThreshold(distanceMeters: distance)
+    }
+
+    /// Build a user-facing kilometer string (e.g. "27 km") from a meters distance.
+    public static func formatKilometers(_ meters: CLLocationDistance) -> String {
+        let km = Int((meters / 1000).rounded())
+        return "\(km) km"
+    }
+}
+
+/// Payload posted on `.didDetectMove` so views can present an alert with the
+/// refined locality + distance.
+public struct MoveDetectedPayload: Sendable {
+    public let savedCityName: String
+    public let detectedCoordinate: CLLocationCoordinate2D
+    public let distanceMeters: CLLocationDistance
+    /// CLGeocoder-resolved locality if available, else empty.
+    public let detectedLocality: String
+
+    public init(
+        savedCityName: String,
+        detectedCoordinate: CLLocationCoordinate2D,
+        distanceMeters: CLLocationDistance,
+        detectedLocality: String
+    ) {
+        self.savedCityName = savedCityName
+        self.detectedCoordinate = detectedCoordinate
+        self.distanceMeters = distanceMeters
+        self.detectedLocality = detectedLocality
+    }
+
+    public var distanceKmString: String {
+        AutoDetectMoveCheck.formatKilometers(distanceMeters)
+    }
+}

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
@@ -9,6 +9,9 @@ public extension Notification.Name {
     /// Posted when the app returns to foreground so prayer-time views recalculate.
     static let refreshPrayerTimes = Notification.Name("refreshPrayerTimes")
     static let openAbout = Notification.Name("openAbout")
+    /// BUG-0069: posted when the launch-time auto-detect check finds the user has moved
+    /// more than 25 km from their saved city. `object` is `MoveDetectedPayload`.
+    static let didDetectMove = Notification.Name("didDetectMove")
     /// Posted when the v1.6 re-detect prompt's "Re-detect" button is tapped.
     /// PrayerTimesView (macOS) / iOSRootView (iOS) opens the Settings sheet in response.
     static let openSettingsForReDetect = Notification.Name("openSettingsForReDetect")
@@ -88,7 +91,7 @@ public class SettingsManager: ObservableObject {
     /// Distance threshold (meters) above which the launch-time auto-detect check
     /// prompts the user to switch cities. Exposed so callers can reference the
     /// same value used by the prompt logic.
-    public static let autoDetectThresholdMeters: CLLocationDistance = 25_000
+    public static let autoDetectThresholdMeters: CLLocationDistance = 25000
 
     // MARK: - Keys synced via iCloud KVS
 

--- a/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
+++ b/Packages/IqamahCore/Sources/IqamahCore/Services/SettingsManager.swift
@@ -80,7 +80,15 @@ public class SettingsManager: ObservableObject {
         static let didShowGPSReDetectPromptV16 = "didShowGPSReDetectPromptV16"
         static let fastingModeSettings = "fastingModeSettings"
         static let didShowFastingModePromo = "didShowFastingModePromo"
+        static let autoDetectOnMove = "autoDetectOnMove"
     }
+
+    // MARK: - BUG-0069 constants
+
+    /// Distance threshold (meters) above which the launch-time auto-detect check
+    /// prompts the user to switch cities. Exposed so callers can reference the
+    /// same value used by the prompt logic.
+    public static let autoDetectThresholdMeters: CLLocationDistance = 25_000
 
     // MARK: - Keys synced via iCloud KVS
 
@@ -109,6 +117,7 @@ public class SettingsManager: ObservableObject {
         Keys.hilalNotificationEnabled,
         Keys.liveActivityEnabled,
         Keys.fastingModeSettings,
+        Keys.autoDetectOnMove,
     ]
 
     @Published public var hasCompletedSetup: Bool {
@@ -299,6 +308,19 @@ public class SettingsManager: ObservableObject {
         }
     }
 
+    /// Opt-in preference (BUG-0069). When true, on launch the app checks the device's
+    /// current GPS coordinate against the saved city. If the user has moved more than
+    /// `autoDetectThresholdMeters` (25 km) away, a non-modal prompt asks whether to
+    /// switch the prayer-times city. We never switch silently. KVS-synced so the user's
+    /// preference follows them across devices.
+    @Published public var autoDetectOnMove: Bool {
+        didSet {
+            defaults.set(autoDetectOnMove, forKey: Keys.autoDetectOnMove)
+            guard !isApplyingRemote else { return }
+            kvs.set(autoDetectOnMove, forKey: Keys.autoDetectOnMove)
+        }
+    }
+
     /// True once the first-Ramadan Fasting Mode promo banner has been shown.
     /// NOT KVS-synced — per-device flag.
     @Published public var didShowFastingModePromo: Bool {
@@ -394,6 +416,13 @@ public class SettingsManager: ObservableObject {
             fastingModeSettings = FastingModeSettings()
         }
         didShowFastingModePromo = userDefaults.bool(forKey: Keys.didShowFastingModePromo)
+
+        // BUG-0069: default true when key has never been written.
+        if userDefaults.object(forKey: Keys.autoDetectOnMove) == nil {
+            autoDetectOnMove = true
+        } else {
+            autoDetectOnMove = userDefaults.bool(forKey: Keys.autoDetectOnMove)
+        }
 
         // Start KVS sync: subscribe to remote changes and trigger an initial pull.
         NotificationCenter.default.addObserver(
@@ -520,6 +549,8 @@ public class SettingsManager: ObservableObject {
             hilalNotificationEnabled = kvs.bool(forKey: key)
         case Keys.liveActivityEnabled:
             liveActivityEnabled = kvs.bool(forKey: key)
+        case Keys.autoDetectOnMove:
+            autoDetectOnMove = kvs.bool(forKey: key)
         case Keys.fastingModeSettings:
             if let data = kvs.data(forKey: key),
                let decoded = try? JSONDecoder().decode(FastingModeSettings.self, from: data) {
@@ -687,6 +718,26 @@ public class SettingsManager: ObservableObject {
     public func hasAnyAdjustments() -> Bool {
         let adjustments = defaults.dictionary(forKey: Keys.prayerAdjustments) as? [String: Int] ?? [:]
         return adjustments.values.contains { $0 != 0 }
+    }
+
+    // MARK: - BUG-0069 distance helper
+
+    /// Great-circle distance in meters between two coordinates. Wraps `CLLocation.distance(from:)`
+    /// so callers don't have to construct intermediate `CLLocation` objects.
+    public static func distance(
+        from a: CLLocationCoordinate2D,
+        to b: CLLocationCoordinate2D
+    ) -> CLLocationDistance {
+        CLLocation(latitude: a.latitude, longitude: a.longitude)
+            .distance(from: CLLocation(latitude: b.latitude, longitude: b.longitude))
+    }
+
+    /// Returns true if the two coordinates are more than `autoDetectThresholdMeters` apart.
+    public static func hasMovedBeyondAutoDetectThreshold(
+        from a: CLLocationCoordinate2D,
+        to b: CLLocationCoordinate2D
+    ) -> Bool {
+        distance(from: a, to: b) > autoDetectThresholdMeters
     }
 
     public func resetAdjustments() {

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/LocationDistanceTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/LocationDistanceTests.swift
@@ -25,8 +25,8 @@ struct LocationDistanceTests {
         let mississauga = CLLocationCoordinate2D(latitude: 43.5890, longitude: -79.6441)
         let d = SettingsManager.distance(from: toronto, to: mississauga)
         // CLLocation returns ~21.5 km along the great circle here; allow a wide band.
-        #expect(d > 20_000)
-        #expect(d < 35_000)
+        #expect(d > 20000)
+        #expect(d < 35000)
     }
 
     @Test("threshold predicate returns false just under 25 km")
@@ -49,24 +49,24 @@ struct LocationDistanceTests {
 
     @Test("threshold constant is 25 km")
     func thresholdConstant() {
-        #expect(SettingsManager.autoDetectThresholdMeters == 25_000)
+        #expect(SettingsManager.autoDetectThresholdMeters == 25000)
     }
 
     // MARK: - autoDetectOnMove round-trip
 
     @Test("autoDetectOnMove defaults to true on a fresh suite")
-    func defaultsToTrue() {
+    func defaultsToTrue() throws {
         let suiteName = "test.LocationDistanceTests.default.\(UUID().uuidString)"
-        let suite = UserDefaults(suiteName: suiteName)!
+        let suite = try #require(UserDefaults(suiteName: suiteName))
         defer { suite.removePersistentDomain(forName: suiteName) }
         let settings = SettingsManager(userDefaults: suite)
         #expect(settings.autoDetectOnMove == true)
     }
 
     @Test("autoDetectOnMove round-trips through UserDefaults")
-    func roundTrip() {
+    func roundTrip() throws {
         let suiteName = "test.LocationDistanceTests.roundtrip.\(UUID().uuidString)"
-        let suite = UserDefaults(suiteName: suiteName)!
+        let suite = try #require(UserDefaults(suiteName: suiteName))
         defer { suite.removePersistentDomain(forName: suiteName) }
         let settings = SettingsManager(userDefaults: suite)
         settings.autoDetectOnMove = false

--- a/Packages/IqamahCore/Tests/IqamahCoreTests/LocationDistanceTests.swift
+++ b/Packages/IqamahCore/Tests/IqamahCoreTests/LocationDistanceTests.swift
@@ -1,0 +1,77 @@
+import CoreLocation
+import Foundation
+import Testing
+@testable import IqamahCore
+
+/// BUG-0069: launch-time auto-detect helpers.
+///
+/// Verifies the great-circle distance helper and the 25 km threshold predicate
+/// used by the "you've moved more than 25 km" launch prompt across iOS, macOS,
+/// and watchOS.
+@Suite("LocationDistance (BUG-0069)")
+struct LocationDistanceTests {
+    // Toronto City Hall — used as the anchor for the threshold tests.
+    private let toronto = CLLocationCoordinate2D(latitude: 43.6534, longitude: -79.3834)
+
+    @Test("zero distance between identical coordinates")
+    func zeroDistance() {
+        let d = SettingsManager.distance(from: toronto, to: toronto)
+        #expect(d == 0)
+    }
+
+    @Test("Toronto → Mississauga is roughly 25–35 km")
+    func knownDistance() {
+        // Mississauga City Hall — ~26 km west of Toronto City Hall.
+        let mississauga = CLLocationCoordinate2D(latitude: 43.5890, longitude: -79.6441)
+        let d = SettingsManager.distance(from: toronto, to: mississauga)
+        // CLLocation returns ~21.5 km along the great circle here; allow a wide band.
+        #expect(d > 20_000)
+        #expect(d < 35_000)
+    }
+
+    @Test("threshold predicate returns false just under 25 km")
+    func underThreshold() {
+        // Construct a point ~24.9 km north of Toronto (1 deg lat ≈ 111 km, so 0.2244° ≈ 24.9 km).
+        let near = CLLocationCoordinate2D(latitude: toronto.latitude + 0.2244, longitude: toronto.longitude)
+        let d = SettingsManager.distance(from: toronto, to: near)
+        #expect(d < SettingsManager.autoDetectThresholdMeters)
+        #expect(!SettingsManager.hasMovedBeyondAutoDetectThreshold(from: toronto, to: near))
+    }
+
+    @Test("threshold predicate returns true just over 25 km")
+    func overThreshold() {
+        // ~25.1 km north of Toronto.
+        let far = CLLocationCoordinate2D(latitude: toronto.latitude + 0.2262, longitude: toronto.longitude)
+        let d = SettingsManager.distance(from: toronto, to: far)
+        #expect(d > SettingsManager.autoDetectThresholdMeters)
+        #expect(SettingsManager.hasMovedBeyondAutoDetectThreshold(from: toronto, to: far))
+    }
+
+    @Test("threshold constant is 25 km")
+    func thresholdConstant() {
+        #expect(SettingsManager.autoDetectThresholdMeters == 25_000)
+    }
+
+    // MARK: - autoDetectOnMove round-trip
+
+    @Test("autoDetectOnMove defaults to true on a fresh suite")
+    func defaultsToTrue() {
+        let suiteName = "test.LocationDistanceTests.default.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: suiteName)!
+        defer { suite.removePersistentDomain(forName: suiteName) }
+        let settings = SettingsManager(userDefaults: suite)
+        #expect(settings.autoDetectOnMove == true)
+    }
+
+    @Test("autoDetectOnMove round-trips through UserDefaults")
+    func roundTrip() {
+        let suiteName = "test.LocationDistanceTests.roundtrip.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: suiteName)!
+        defer { suite.removePersistentDomain(forName: suiteName) }
+        let settings = SettingsManager(userDefaults: suite)
+        settings.autoDetectOnMove = false
+
+        let reloaded = SettingsManager(userDefaults: suite)
+        #expect(reloaded.autoDetectOnMove == false)
+    }
+}

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -4,13 +4,46 @@ All bugs and defects tracked here with BUG-XXXX identifiers and status.
 
 ---
 
-**Total Active Bugs:** 1
+**Total Active Bugs:** 2
 **Critical:** 1
-**High:** 0
+**High:** 1
 **Medium:** 0
 **Low:** 0
 
-> **All bugs BUG-0001 through BUG-0067 resolved as of 2026-05-20.** One open bug (BUG-0068) blocking App Store approval of v1.5 (13) submission.
+> **All bugs BUG-0001 through BUG-0067 resolved as of 2026-05-20.** One open bug (BUG-0068) blocking App Store approval of v1.5 (13) submission; BUG-0069 (location detect) reported on v1.5 build 14.
+
+---
+
+## Session — 2026-05-24 (Location detection feedback — v1.5 build 14)
+
+### Open
+
+**BUG-0069 (iOS/macOS/watchOS): Location detection cached incorrectly + no auto-detect after first run**
+
+**Severity:** 🟠 P1 — High (user-visible misbehavior; affects prayer-time accuracy in suburbs and after travel)
+**Reported:** 2026-05-24 — user feedback on v1.5 (14)
+**Status:** 🔴 Open
+**Affected platforms:** macOS, iOS, watchOS
+**Affected versions:** v1.5 (14) and earlier
+
+**Description:** Three layered gaps in the location-detection flow combine to make Iqamah show the wrong city for users in suburbs and after travel:
+
+1. **Catalog snap masks actual locality.** `LocationSetupView.detectClosestCity()` snaps the picker to the nearest entry in `cities.json` (e.g. "Calgary") even when GPS reports a different suburb (e.g. "Airdrie"). `reverseGeocodeAndUpdate()` exists but runs *after* the user taps Continue, so the picker always shows the catalog name during selection.
+2. **Detected city is not in the picker's list.** The user's actual GPS-detected locality is persisted to `SettingsManager.selectedCity*` keys but never appears as a selectable entry in the City picker. Opening the picker later in Settings shows only catalog cities; switching away and back loses the GPS context.
+3. **No auto-detect after first launch.** `ContentView` (macOS) and `iOSRootView` skip `LocationSetupView` once `hasCompletedSetup == true`, so re-opening the app in a new city does nothing. The picker continues showing whatever was saved on first run even when the device's GPS reports a clearly different location.
+
+**Reproduction (gap 1):** Install fresh in Airdrie, AB. Tap through onboarding — picker shows "Calgary" despite GPS coordinates being in Airdrie.
+
+**Reproduction (gap 3):** Complete onboarding in Toronto. Travel to Calgary. Re-open the app — still shows Toronto with no prompt to re-detect.
+
+**Fix scope:**
+1. Surface a "Current Location" entry at the top of the city picker (macOS+iOS shared `LocationSetupView`, `SettingsSheetView`, and watchOS `SettingsTab`) showing the geocoded locality with the `location.fill` icon. Selecting it persists the refined `City` (locality name + raw GPS coords + geocoded timezone).
+2. Pre-resolve `CLGeocoder` immediately when GPS resolves (in the `onChange` handler, not the Continue handler), so the picker shows the refined name before the user interacts.
+3. Cache the refined city on `SettingsManager.gpsDetectedCity` (already wired) and read it from every picker.
+4. Add an opt-in `autoDetectOnMove` toggle (default `true`, KVS-synced). On launch, if the user has moved > 25 km from their saved city, prompt to switch — never auto-switch silently. Uses one-shot `requestLocation()`, NOT `significantLocationChanges`, and does NOT request "Always" permission.
+5. Surface the toggle in `SettingsSheetView` (macOS+iOS) and `SettingsTab` (watchOS) under the Location section.
+
+**Out of scope (follow-ups):** snapshot tests for the new picker UI; significant-location-change monitoring (intentionally one-shot only).
 
 ---
 

--- a/docs/ID_REGISTRY.md
+++ b/docs/ID_REGISTRY.md
@@ -13,7 +13,7 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 | TASK         | TASK-0001             | None              |
 | AC           | AC-0383               | AC-0382           |
 | TC           | TC-0074               | TC-0073           |
-| BUG          | BUG-0069              | BUG-0068          |
+| BUG          | BUG-0070              | BUG-0069          |
 | ENH          | ENH-027               | ENH-026           |
 
 ---
@@ -28,4 +28,4 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 
 ---
 
-**Last Updated:** 2026-05-23 (EPIC-0017 closed — Fasting Mode: US-0071–US-0075, AC-0357–AC-0382, TC-0044–TC-0073 consumed; ENH-022 stub for celebration reminders backfilled.)
+**Last Updated:** 2026-05-24 (BUG-0069 logged — location detection cached incorrectly + no auto-detect after first run; affects iOS/macOS/watchOS.)

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		AA0000000000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000012 /* ContentView.swift */; };
 		WI000000000000000000001 /* WatchAppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = WI000000000000000000001R /* WatchAppIconView.swift */; };
 		AA0000000000000000000008 /* LocationSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000018 /* LocationSetupView.swift */; };
+		BUG69A0000000000000000001 /* AutoDetectMoveToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BUG69A0000000000000000003 /* AutoDetectMoveToggle.swift */; };
+		BUG69A0000000000000000002 /* AutoDetectMoveToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BUG69A0000000000000000003 /* AutoDetectMoveToggle.swift */; };
 		AA0000000000000000000009 /* CalculationMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000019 /* CalculationMethodView.swift */; };
 		AA000000000000000000000A /* PrayerTimesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000001A /* PrayerTimesView.swift */; };
 		AA000000000000000000000C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000001C /* Assets.xcassets */; };
@@ -274,6 +276,7 @@
 		AA0000000000000000000012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		WI000000000000000000001R /* WatchAppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchAppIconView.swift; sourceTree = "<group>"; };
 		AA0000000000000000000018 /* LocationSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSetupView.swift; sourceTree = "<group>"; };
+		BUG69A0000000000000000003 /* AutoDetectMoveToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectMoveToggle.swift; sourceTree = "<group>"; };
 		AA0000000000000000000019 /* CalculationMethodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculationMethodView.swift; sourceTree = "<group>"; };
 		AA000000000000000000001A /* PrayerTimesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerTimesView.swift; sourceTree = "<group>"; };
 		AA000000000000000000001C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -574,6 +577,7 @@
 			isa = PBXGroup;
 			children = (
 				AA0000000000000000000018 /* LocationSetupView.swift */,
+				BUG69A0000000000000000003 /* AutoDetectMoveToggle.swift */,
 				AA0000000000000000000019 /* CalculationMethodView.swift */,
 				AA000000000000000000001A /* PrayerTimesView.swift */,
 				94CAD56A2F23D3C800E1689F /* SplashScreenView.swift */,
@@ -1165,6 +1169,7 @@
 				FB000000000000000000003 /* FastingModeSection.swift in Sources */,
 				BN000000000000000000BB02 /* AdhaanBannerController.swift in Sources */,
 				AA0000000000000000000008 /* LocationSetupView.swift in Sources */,
+				BUG69A0000000000000000001 /* AutoDetectMoveToggle.swift in Sources */,
 				AA0000000000000000000009 /* CalculationMethodView.swift in Sources */,
 				AA000000000000000000000A /* PrayerTimesView.swift in Sources */,
 				AA000000000000000000000D /* QiblahView.swift in Sources */,
@@ -1264,6 +1269,7 @@
 				iOS0000000000000000000002 /* iOSRootView.swift in Sources */,
 				iOS0000000000000000000003 /* PrayerTimesView.swift in Sources */,
 				iOS0000000000000000000004 /* LocationSetupView.swift in Sources */,
+				BUG69A0000000000000000002 /* AutoDetectMoveToggle.swift in Sources */,
 				iOS0000000000000000000005 /* CalculationMethodView.swift in Sources */,
 				iOS0000000000000000000006 /* SettingsSheetView.swift in Sources */,
 				iOS0000000000000000000007 /* AdhaanBannerView.swift in Sources */,

--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -18,6 +18,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var announcedPrayers: Set<String> = []
     private var announcedDate = Date()
 
+    // BUG-0069: held strongly so the one-shot CLLocationManager callback fires.
+    // Accessed by the extension below; SwiftLint's strict_fileprivate rule allows
+    // this when the access is needed across same-file extensions.
+    // swiftlint:disable:next strict_fileprivate
+    fileprivate var autoDetectLocationService: LocationService?
+
     func applicationDidFinishLaunching(_: Notification) {
         // Bootstrap UI test state before any other setup so SettingsManager
         // reads the seeded city when ContentView first renders.
@@ -55,6 +61,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 window.center()
             }
         }
+
+        // BUG-0069: launch-time auto-detect (opt-in, one-shot). Skips silently if the
+        // user hasn't completed setup or has disabled the toggle.
+        performAutoDetectMoveCheck()
     }
 
     @objc private func settingsDidChange() {
@@ -509,6 +519,52 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             startUpdateTimer()
         } else {
             updateStatusBarDisplay()
+        }
+    }
+}
+
+// MARK: - BUG-0069 auto-detect (extracted to keep AppDelegate under type_body_length)
+
+extension AppDelegate {
+    @MainActor
+    func performAutoDetectMoveCheck() {
+        let settings = SettingsManager.shared
+        guard settings.hasCompletedSetup, settings.autoDetectOnMove else { return }
+        guard settings.loadCity() != nil else { return }
+
+        let service = LocationService()
+        autoDetectLocationService = service
+        Task { @MainActor in
+            do {
+                let coord = try await service.requestLocationAsync()
+                let outcome = AutoDetectMoveCheck.evaluate(
+                    settings: settings,
+                    currentCoordinate: coord
+                )
+                guard case let .shouldPrompt(distance, savedName) = outcome else {
+                    autoDetectLocationService = nil
+                    return
+                }
+                CLGeocoder().reverseGeocodeLocation(
+                    CLLocation(latitude: coord.latitude, longitude: coord.longitude)
+                ) { placemarks, _ in
+                    let locality = placemarks?.first?.locality
+                        ?? placemarks?.first?.name
+                        ?? ""
+                    DispatchQueue.main.async {
+                        let payload = MoveDetectedPayload(
+                            savedCityName: savedName,
+                            detectedCoordinate: coord,
+                            distanceMeters: distance,
+                            detectedLocality: locality
+                        )
+                        NotificationCenter.default.post(name: .didDetectMove, object: payload)
+                        self.autoDetectLocationService = nil
+                    }
+                }
+            } catch {
+                autoDetectLocationService = nil
+            }
         }
     }
 }

--- a/iqamah/ContentView.swift
+++ b/iqamah/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @StateObject private var settings = SettingsManager.shared
     @State private var currentScreen: AppScreen = .splash
     @State private var showLegacyReDetectPrompt = false
+    @State private var moveDetected: MoveDetectedPayload?
     @State private var selectedCity: City?
     @State private var calculationMethod: CalculationMethod = .muslimWorldLeague
     @State private var asrMethod: AsrJuristicMethod = .standard
@@ -120,6 +121,52 @@ struct ContentView: View {
         } message: {
             Text(
                 "Iqamah v1.6 uses your exact GPS position and authoritative timezone for prayer-time calculations. Re-detect your location now to apply the improvement?"
+            )
+        }
+        // BUG-0069: launch-time auto-detect prompt
+        .onReceive(NotificationCenter.default.publisher(for: .didDetectMove)) { note in
+            if let payload = note.object as? MoveDetectedPayload {
+                moveDetected = payload
+            }
+        }
+        .alert(
+            "Have you moved?",
+            isPresented: Binding(
+                get: { moveDetected != nil },
+                set: { if !$0 { moveDetected = nil } }
+            ),
+            presenting: moveDetected
+        ) { payload in
+            Button("Switch") {
+                let locality = payload.detectedLocality.isEmpty
+                    ? payload.savedCityName
+                    : payload.detectedLocality
+                if let newCity = try? City(
+                    name: locality,
+                    countryCode: settings.loadCity()?.countryCode ?? "US",
+                    latitude: payload.detectedCoordinate.latitude,
+                    longitude: payload.detectedCoordinate.longitude,
+                    timezone: TimeZone.current.identifier
+                ) {
+                    settings.saveCity(newCity)
+                    settings.locationSource = "gps"
+                    settings.saveGPSCoordinates(payload.detectedCoordinate)
+                    settings.gpsLocality = payload.detectedLocality
+                    settings.gpsDetectedCity = newCity
+                    selectedCity = newCity
+                    NotificationCenter.default.post(name: .settingsDidChange, object: nil)
+                }
+                moveDetected = nil
+            }
+            Button("Not now", role: .cancel) {
+                moveDetected = nil
+            }
+        } message: { payload in
+            let whereText = payload.detectedLocality.isEmpty
+                ? "your current location"
+                : payload.detectedLocality
+            Text(
+                "It looks like you're in \(whereText), about \(payload.distanceKmString) from \(payload.savedCityName). Switch your prayer-times city?"
             )
         }
         .preferredColorScheme(settings.appearance.colorScheme)

--- a/iqamah/Views/AutoDetectMoveToggle.swift
+++ b/iqamah/Views/AutoDetectMoveToggle.swift
@@ -1,0 +1,27 @@
+import IqamahCore
+import SwiftUI
+
+// MARK: - BUG-0069 auto-detect toggle
+
+//
+// Extracted from SettingsSheetView so the parent file stays under the
+// `file_length` SwiftLint rule. Shared between macOS and iOS.
+
+struct AutoDetectMoveToggle: View {
+    @ObservedObject var settings: SettingsManager
+
+    var body: some View {
+        Toggle(isOn: $settings.autoDetectOnMove) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Auto-detect if I move > 25 km")
+                Text("On launch, check your current location and offer to switch cities if you've moved.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .toggleStyle(.switch)
+        .help(
+            "On launch, check your current location and prompt to switch cities if you've moved more than 25 kilometers from your saved city."
+        )
+    }
+}

--- a/iqamah/Views/LocationSetupView.swift
+++ b/iqamah/Views/LocationSetupView.swift
@@ -109,6 +109,19 @@ struct LocationSetupView: View {
                                 Text("City").font(.headline)
                                 Picker("City", selection: $selectedCity) {
                                     Text("Select a city").tag(nil as City?)
+                                    // BUG-0069: surface the GPS-detected (and CLGeocoder-refined)
+                                    // city at the top of the picker so the user can confirm the
+                                    // exact locality (e.g. "Airdrie") instead of a nearest-catalog
+                                    // snap (e.g. "Calgary").
+                                    if let gpsCity = SettingsManager.shared.gpsDetectedCity,
+                                       gpsCity.countryCode == selectedCountry?.code {
+                                        Label(
+                                            "Current Location: \(gpsCity.name)",
+                                            systemImage: "location.fill"
+                                        )
+                                        .tag(gpsCity as City?)
+                                        Divider()
+                                    }
                                     ForEach(database.cities(forCountryCode: selectedCountry?.code ?? "")) { city in
                                         Text(city.name).tag(city as City?)
                                     }
@@ -139,22 +152,30 @@ struct LocationSetupView: View {
                 Spacer()
                 Button(action: {
                     guard let city = selectedCity else { return }
-                    if hasDetectedLocation, let coord = rawGPSCoordinate {
-                        // ENH-001 Option A: use raw GPS coords + TimeZone.current
+                    // BUG-0069: if the user selected the "Current Location" row (which is
+                    // the cached gpsDetectedCity), treat it as GPS source. Otherwise this
+                    // is a manual selection from the catalog.
+                    let isGPSChoice = hasDetectedLocation
+                        && SettingsManager.shared.gpsDetectedCity?.name == city.name
+                    if isGPSChoice, let coord = rawGPSCoordinate {
                         SettingsManager.shared.locationSource = "gps"
                         SettingsManager.shared.saveGPSCoordinates(coord)
-                        SettingsManager.shared.gpsTimezone = TimeZone.current.identifier
-                        guard let gpsCity = try? City(
+                        // Use the geocoded timezone if available, else fall back to system.
+                        let tz = SettingsManager.shared.gpsTimezone.isEmpty
+                            ? TimeZone.current.identifier
+                            : SettingsManager.shared.gpsTimezone
+                        SettingsManager.shared.gpsTimezone = tz
+                        let gpsCity = (try? City(
                             name: city.name,
                             countryCode: city.countryCode,
                             latitude: coord.latitude,
                             longitude: coord.longitude,
-                            timezone: TimeZone.current.identifier
-                        ) else { return }
+                            timezone: tz
+                        )) ?? city
+                        SettingsManager.shared.gpsDetectedCity = gpsCity
                         onLocationConfirmed(gpsCity)
-                        reverseGeocodeAndUpdate(coordinate: coord)
                     } else {
-                        // ENH-001 manual path
+                        // Manual catalog selection — clear GPS source.
                         SettingsManager.shared.locationSource = "manual"
                         onLocationConfirmed(city)
                     }
@@ -215,19 +236,41 @@ struct LocationSetupView: View {
             selectedCountry = database.country(forCode: closestCity.countryCode)
             hasDetectedLocation = true
             rawGPSCoordinate = coordinate // ENH-001: capture raw GPS coordinate
+
+            // BUG-0069: seed gpsDetectedCity immediately so the picker's "Current Location"
+            // row appears (initially with the catalog name + GPS coordinates). The geocoder
+            // then refines it to the actual locality (e.g. "Airdrie" instead of "Calgary").
+            let seededCity = (try? City(
+                name: closestCity.name,
+                countryCode: closestCity.countryCode,
+                latitude: coordinate.latitude,
+                longitude: coordinate.longitude,
+                timezone: TimeZone.current.identifier
+            )) ?? closestCity
+            SettingsManager.shared.gpsDetectedCity = seededCity
+
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                selectedCity = closestCity
+                selectedCity = seededCity
                 withAnimation(.spring(response: 0.4)) {
                     showDetectedBadge = true
                 }
             }
+
+            // BUG-0069: pre-resolve geocoder right after GPS so picker shows the
+            // refined locality BEFORE the user taps Continue.
+            reverseGeocodeAndUpdate(coordinate: coordinate)
         }
     }
 
-    // ENH-001 Option B: CLGeocoder refines locality and timezone asynchronously
+    // ENH-001 Option B / BUG-0069: CLGeocoder refines locality and timezone asynchronously.
+    // Now invoked BEFORE the user taps Continue so the "Current Location" picker entry
+    // displays the refined locality name (e.g. "Airdrie") rather than the nearest catalog
+    // city name (e.g. "Calgary").
     private func reverseGeocodeAndUpdate(coordinate: CLLocationCoordinate2D) {
-        // Skip if same location as cache (within 5 km)
-        if let cached = SettingsManager.shared.cachedGPSCoordinate() {
+        // Skip if same location as cache (within 5 km) — BUT only if we already have a
+        // gpsDetectedCity from a prior run. On first detect we always want to refine.
+        if let cached = SettingsManager.shared.cachedGPSCoordinate(),
+           SettingsManager.shared.gpsDetectedCity != nil {
             let cachedLoc = CLLocation(latitude: cached.latitude, longitude: cached.longitude)
             let newLoc = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
             if cachedLoc.distance(from: newLoc) < 5000,
@@ -238,28 +281,37 @@ struct LocationSetupView: View {
             CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
         ) { placemarks, error in
             guard error == nil, let placemark = placemarks?.first else {
-                print("[ENH-001] CLGeocoder failed: \(error?.localizedDescription ?? "unknown")")
+                print("[BUG-0069] CLGeocoder failed: \(error?.localizedDescription ?? "unknown")")
                 return
             }
             let locality = placemark.locality ?? placemark.name ?? SettingsManager.shared.gpsLocality
             let timezone = placemark.timeZone?.identifier ?? TimeZone.current.identifier
+            let countryCode = placemark.isoCountryCode
+                ?? SettingsManager.shared.gpsDetectedCity?.countryCode
+                ?? SettingsManager.shared.loadCity()?.countryCode
+                ?? "US"
 
             DispatchQueue.main.async {
-                // Single source of truth: same helper used by IqamahWatchApp.refineWithCLGeocoder.
+                // Single source of truth for the locality/timezone fields.
                 SettingsManager.shared.applyGeocodingRefinement(
                     locality: locality,
                     timezoneIdentifier: timezone
                 )
-                // Refine the saved city name and timezone with authoritative values
-                if let city = SettingsManager.shared.loadCity(),
-                   let refined = try? City(
-                       name: locality,
-                       countryCode: city.countryCode,
-                       latitude: coordinate.latitude,
-                       longitude: coordinate.longitude,
-                       timezone: timezone
-                   ) {
-                    SettingsManager.shared.saveCity(refined)
+                // BUG-0069: update the cached GPS city with the refined locality so the
+                // picker's "Current Location" row reflects the geocoder result.
+                if let refined = try? City(
+                    name: locality,
+                    countryCode: countryCode,
+                    latitude: coordinate.latitude,
+                    longitude: coordinate.longitude,
+                    timezone: timezone
+                ) {
+                    SettingsManager.shared.gpsDetectedCity = refined
+                    // If the user hasn't manually overridden their selection, update
+                    // the picker selection to the refined city as well.
+                    if hasDetectedLocation {
+                        selectedCity = refined
+                    }
                 }
             }
         }

--- a/iqamah/Views/SettingsSheetView.swift
+++ b/iqamah/Views/SettingsSheetView.swift
@@ -149,6 +149,9 @@ struct SettingsSheetView: View {
         } else {
             ProgressView("Loading cities…")
         }
+
+        // BUG-0069: opt-in auto-detect toggle (extracted to AutoDetectMoveToggle).
+        AutoDetectMoveToggle(settings: settings)
     }
 
     private func detectLocation() {

--- a/iqamah/Views/SettingsSheetView.swift
+++ b/iqamah/Views/SettingsSheetView.swift
@@ -132,10 +132,14 @@ struct SettingsSheetView: View {
             if selectedCountry != nil {
                 Picker("City", selection: $selectedCity) {
                     Text("Select a city").tag(nil as City?)
-                    // GPS-detected city injected at top when country matches
+                    // BUG-0069: surface the GPS-detected (geocoded) city at the top of
+                    // the picker so users can always pick their actual locality even when
+                    // it doesn't exist in cities.json.
                     if let gpsCity = SettingsManager.shared.gpsDetectedCity,
                        gpsCity.countryCode == selectedCountry?.code {
-                        Text("📍 \(gpsCity.name) (GPS)").tag(gpsCity as City?)
+                        Label("Current Location: \(gpsCity.name)", systemImage: "location.fill")
+                            .tag(gpsCity as City?)
+                        Divider()
                     }
                     ForEach(cities) { city in
                         Text(city.name).tag(city as City?)

--- a/iqamah/iOS/iOSRootView.swift
+++ b/iqamah/iOS/iOSRootView.swift
@@ -7,6 +7,7 @@ struct IOSRootView: View {
     @State private var selectedTab: Int = 0
     @State private var showHilalWatch = false
     @State private var showLegacyReDetectPrompt = false
+    @State private var moveDetected: MoveDetectedPayload?
 
     var body: some View {
         if settings.hasCompletedSetup {
@@ -43,6 +44,51 @@ struct IOSRootView: View {
                 } message: {
                     Text(
                         "Iqamah v1.6 uses your exact GPS position and authoritative timezone for prayer-time calculations. Re-detect your location now to apply the improvement?"
+                    )
+                }
+                // BUG-0069: launch-time auto-detect prompt
+                .onReceive(NotificationCenter.default.publisher(for: .didDetectMove)) { note in
+                    if let payload = note.object as? MoveDetectedPayload {
+                        moveDetected = payload
+                    }
+                }
+                .alert(
+                    "Have you moved?",
+                    isPresented: Binding(
+                        get: { moveDetected != nil },
+                        set: { if !$0 { moveDetected = nil } }
+                    ),
+                    presenting: moveDetected
+                ) { payload in
+                    Button("Switch") {
+                        let locality = payload.detectedLocality.isEmpty
+                            ? payload.savedCityName
+                            : payload.detectedLocality
+                        if let newCity = try? City(
+                            name: locality,
+                            countryCode: settings.loadCity()?.countryCode ?? "US",
+                            latitude: payload.detectedCoordinate.latitude,
+                            longitude: payload.detectedCoordinate.longitude,
+                            timezone: TimeZone.current.identifier
+                        ) {
+                            settings.saveCity(newCity)
+                            settings.locationSource = "gps"
+                            settings.saveGPSCoordinates(payload.detectedCoordinate)
+                            settings.gpsLocality = payload.detectedLocality
+                            settings.gpsDetectedCity = newCity
+                            NotificationCenter.default.post(name: .settingsDidChange, object: nil)
+                        }
+                        moveDetected = nil
+                    }
+                    Button("Not now", role: .cancel) {
+                        moveDetected = nil
+                    }
+                } message: { payload in
+                    let whereText = payload.detectedLocality.isEmpty
+                        ? "your current location"
+                        : payload.detectedLocality
+                    Text(
+                        "It looks like you're in \(whereText), about \(payload.distanceKmString) from \(payload.savedCityName). Switch your prayer-times city?"
                     )
                 }
         } else {

--- a/iqamah/iOS/iqamahApp_iOS.swift
+++ b/iqamah/iOS/iqamahApp_iOS.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import IqamahCore
 import SwiftUI
 import WatchConnectivity
@@ -7,6 +8,8 @@ import WidgetKit
 struct IqamahiOSApp: App {
     @StateObject private var settings = SettingsManager.shared
     @Environment(\.scenePhase) private var scenePhase
+    // BUG-0069: held strongly so the one-shot CLLocationManager callback fires.
+    @State private var autoDetectLocationService: LocationService?
 
     init() {
         // Pre-seed Toronto / ISNA settings so XCUITests skip setup flow (AC-0326, US-0067).
@@ -41,6 +44,7 @@ struct IqamahiOSApp: App {
                 .onAppear {
                     activateWCSession()
                     NotificationScheduler.shared.requestFastingReschedule()
+                    performAutoDetectMoveCheck()
                 }
                 .onChange(of: settings.fastingModeSettings) { _, _ in
                     NotificationScheduler.shared.requestFastingReschedule()
@@ -95,6 +99,45 @@ struct IqamahiOSApp: App {
                         await PrayerActivityManager.shared.startOrUpdateActivity(settings: settings)
                     }
                 }
+        }
+    }
+
+    /// BUG-0069: launch-time auto-detect (opt-in). Skips silently if disabled or onboarding incomplete.
+    @MainActor
+    private func performAutoDetectMoveCheck() {
+        guard settings.hasCompletedSetup, settings.autoDetectOnMove else { return }
+        guard settings.loadCity() != nil else { return }
+        let service = LocationService()
+        autoDetectLocationService = service
+        Task { @MainActor in
+            do {
+                let coord = try await service.requestLocationAsync()
+                let outcome = AutoDetectMoveCheck.evaluate(
+                    settings: settings,
+                    currentCoordinate: coord
+                )
+                guard case let .shouldPrompt(distance, savedName) = outcome else {
+                    autoDetectLocationService = nil
+                    return
+                }
+                CLGeocoder().reverseGeocodeLocation(
+                    CLLocation(latitude: coord.latitude, longitude: coord.longitude)
+                ) { placemarks, _ in
+                    let locality = placemarks?.first?.locality ?? placemarks?.first?.name ?? ""
+                    DispatchQueue.main.async {
+                        let payload = MoveDetectedPayload(
+                            savedCityName: savedName,
+                            detectedCoordinate: coord,
+                            distanceMeters: distance,
+                            detectedLocality: locality
+                        )
+                        NotificationCenter.default.post(name: .didDetectMove, object: payload)
+                        autoDetectLocationService = nil
+                    }
+                }
+            } catch {
+                autoDetectLocationService = nil
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes [BUG-0069](docs/BUGS.md) — three layered gaps in location detection across iOS, macOS, and watchOS:

> 1. **Catalog snap masks actual locality.** `LocationSetupView.detectClosestCity()` snaps the picker to the nearest entry in `cities.json` (e.g. "Calgary") even when GPS reports a different suburb (e.g. "Airdrie"). `reverseGeocodeAndUpdate()` exists but runs *after* the user taps Continue, so the picker always shows the catalog name during selection.
> 2. **Detected city is not in the picker's list.** The user's actual GPS-detected locality is persisted to `SettingsManager.selectedCity*` keys but never appears as a selectable entry in the City picker.
> 3. **No auto-detect after first launch.** `ContentView` (macOS) and `iOSRootView` skip `LocationSetupView` once `hasCompletedSetup == true`, so re-opening the app in a new city does nothing.

## Fixes

1. **`SettingsManager.autoDetectOnMove`** (default `true`, KVS-synced) and `autoDetectThresholdMeters = 25_000` constant, plus a static `distance(from:to:)` great-circle helper and `hasMovedBeyondAutoDetectThreshold` predicate.
2. **"Current Location" picker row** with `location.fill` glyph at the top of `LocationSetupView`, `SettingsSheetView`, and the watch `SettingsTab → WatchCityPicker`. Selecting it persists the refined `City` (locality + raw GPS coords + geocoded timezone) and sets `locationSource = "gps"`.
3. **Pre-resolve `CLGeocoder` on GPS resolve** (in the `onChange(currentLocation)` handler, not the Continue handler) so the picker shows the refined locality immediately. Refined city writes back to `SettingsManager.gpsDetectedCity` so it's available everywhere.
4. **Launch-time auto-detect** wired into `iqamah/AppDelegate`, `iqamah/iOS/iqamahApp_iOS`, and `IqamahWatch/IqamahWatchApp` — when enabled, fires a one-shot `requestLocation()`, computes distance, and surfaces a "Have you moved?" alert with [Switch] / [Not now]. **Never auto-switches**; **never requests `Always` permission**; **does not** use significant-location-change monitoring.
5. **Settings toggle** ("Auto-detect if I move > 25 km") added to `SettingsSheetView` (macOS+iOS, extracted to `AutoDetectMoveToggle.swift` to satisfy `file_length`) and to the watch `SettingsTab` Location section.

## Tests

- New `LocationDistanceTests.swift` (Swift Testing, 7 tests): distance round-trip, threshold predicate at 24.9 km and 25.1 km, threshold constant, `autoDetectOnMove` default and round-trip.
- `swift test` → 258 tests pass.

Snapshot tests for the new "Current Location" picker UI are intentionally deferred as a follow-up.

## Verification

- `swift build && swift test` clean — 258 tests pass.
- `xcodebuild` clean for `iqamah` (macOS), `iqamah-iOS`, and `IqamahWatch`.
- `swiftformat --lint --strict` clean for all touched files.
- `swiftlint lint --strict` clean — 0 violations across 41 files.

## Test plan

- [ ] **Fresh install in a suburb (macOS)** — onboarding picker shows "Current Location: <locality>" (e.g. "Airdrie") with `location.fill` icon, refined after geocoder resolves. Catalog cities still selectable below the divider.
- [ ] **Fresh install in a suburb (iOS)** — same as above on iPhone.
- [ ] **Settings → City picker (macOS, iOS)** — "Current Location" row appears at top when country matches the GPS-detected country; selecting it sets `locationSource = "gps"` and persists.
- [ ] **Settings → Set City Manually (watchOS)** — drilling into the matching country shows "Current Location" section at top; selecting it switches to `gps` source.
- [ ] **Launch-time auto-detect (all 3 platforms)** — set city to Toronto, change device location to a city > 25 km away, relaunch the app, see "Have you moved?" alert with distance + locality. Tap **Switch** → city updates. Tap **Not now** → city stays.
- [ ] **Toggle off** → no prompt on next launch even after a > 25 km move.
- [ ] **Within threshold** (< 25 km) → no prompt.

Cross-references: [BUG-0069 in docs/BUGS.md](docs/BUGS.md), ID registry updated to BUG-0070 next.