### PR TITLE
docs: close BUG-0068/BUG-0069 + renumber ENH IDs to 4-digit format

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -10,7 +10,7 @@ All bugs and defects tracked here with BUG-XXXX identifiers and status.
 **Medium:** 0
 **Low:** 0
 
-> **All bugs BUG-0001 through BUG-0067 resolved as of 2026-05-20.** One open bug (BUG-0068) blocking App Store approval of v1.5 (13) submission; BUG-0069 (location detect) reported on v1.5 build 14.
+> **All bugs BUG-0001 through BUG-0069 resolved as of 2026-05-24.** v1.5 (15) accepted by App Store; v1.6.0 in development.
 
 ---
 
@@ -49,13 +49,13 @@ All bugs and defects tracked here with BUG-XXXX identifiers and status.
 
 ## Session — 2026-05-21 (App Store rejection — v1.5 build 13)
 
-### Open
+### Resolved
 
 **BUG-0068 (watchOS): Watch app icon black background — App Store rejection (Guideline 4 — Design)**
 
 **Severity:** 🔴 Critical (blocks App Store approval of v1.5 (13) submission)
 **Discovered:** 2026-05-21 — App Store review feedback
-**Status:** 🔴 Open
+**Status:** ✅ Fixed — accepted in App Store v1.5 (15)
 **Submission ID:** b0de0a72-84bc-4693-81df-4d8f7bfac818
 **Review device:** Apple Watch and iPhone 17 Pro Max
 **Version reviewed:** 1.5 (13)

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -16,13 +16,13 @@ All bugs and defects tracked here with BUG-XXXX identifiers and status.
 
 ## Session — 2026-05-24 (Location detection feedback — v1.5 build 14)
 
-### Open
+### Resolved
 
 **BUG-0069 (iOS/macOS/watchOS): Location detection cached incorrectly + no auto-detect after first run**
 
 **Severity:** 🟠 P1 — High (user-visible misbehavior; affects prayer-time accuracy in suburbs and after travel)
 **Reported:** 2026-05-24 — user feedback on v1.5 (14)
-**Status:** 🔴 Open
+**Status:** ✅ Fixed — PR #140 (commit 860b028)
 **Affected platforms:** macOS, iOS, watchOS
 **Affected versions:** v1.5 (14) and earlier
 

--- a/docs/ENHANCEMENTS.md
+++ b/docs/ENHANCEMENTS.md
@@ -3,18 +3,18 @@
 Logged from competitive analysis (May 2026) and product research. Items are grouped by theme, not priority. See competitive-analysis.md for the feature gap matrix these derive from.
 
 **Implementation status as of 2026-05-20:**
-- ENH-015 (iPhone/iPad) → ✅ Implemented as EPIC-0010 (PRs #56–60). Submitted to App Store 2026-05-20.
-- ENH-016 (Apple Watch) → ✅ Implemented as EPIC-0012 (PR #67). Submitted to App Store 2026-05-20.
-- ENH-018 (Hilal Watch) → ✅ Implemented as EPIC-0011 (PRs #61–66). Submitted to App Store 2026-05-20.
-- ENH-019 (i18n) → 🔵 Planned — not yet started
-- ENH-020 (Apple TV) → 🔵 Backlog — see Platform Expansion section
-- ENH-021 (visionOS) → 🔵 Backlog — see Platform Expansion section
+- ENH-0015 (iPhone/iPad) → ✅ Implemented as EPIC-0010 (PRs #56–60). Submitted to App Store 2026-05-20.
+- ENH-0016 (Apple Watch) → ✅ Implemented as EPIC-0012 (PR #67). Submitted to App Store 2026-05-20.
+- ENH-0018 (Hilal Watch) → ✅ Implemented as EPIC-0011 (PRs #61–66). Submitted to App Store 2026-05-20.
+- ENH-0019 (i18n) → 🔵 Planned — not yet started
+- ENH-0020 (Apple TV) → 🔵 Backlog — see Platform Expansion section
+- ENH-0021 (visionOS) → 🔵 Backlog — see Platform Expansion section
 
 ---
 
 ## Location Accuracy
 
-### ENH-001 — Exact GPS Prayer Times via CLGeocoder (Option A + B) ✅ Implemented (2026-05-21)
+### ENH-0001 — Exact GPS Prayer Times via CLGeocoder (Option A + B) ✅ Implemented (2026-05-21)
 **Status:** ✅ Fully implemented across all platforms. A+B shipped during v1.5.0 (macOS/iOS first-launch and Settings re-detect); watchOS Option B parity, a one-time v1.6 re-detect prompt for legacy users, and structural cleanups landed in the v1.6 cycle (see docs/superpowers/specs/2026-05-21-enh-001-finish-up-design.md).
 
 | Surface | Option | Location |
@@ -41,7 +41,7 @@ Logged from competitive analysis (May 2026) and product research. Items are grou
 
 ## Ramadan / Seasonal Features
 
-### ENH-002 — Fasting Mode (Suhoor & Iftar Countdowns + Nawafil Triggers) ✅ Implemented (2026-05-21)
+### ENH-0002 — Fasting Mode (Suhoor & Iftar Countdowns + Nawafil Triggers) ✅ Implemented (2026-05-21)
 **Status:** ✅ Implemented as EPIC-0017 (US-0071–US-0075 shipped in v1.6). Generalized from Ramadan-only mode to a Fasting Mode covering 9 activation triggers (auto-Ramadan, weekly schedule, Ayyam al-Beed, 6 of Shawwal, Day of Arafah, first 9 of Dhul-Hijjah, Muharram fast, 15 Sha'ban, 27 Rajab). Tradition-aware UI gating driven by `isShiaMethod` helper; Ja'fari calculation method added alongside Tehran. Spec at `docs/superpowers/specs/2026-05-21-fasting-mode-design.md`.
 
 | Surface | Treatment |
@@ -56,7 +56,7 @@ Logged from competitive analysis (May 2026) and product research. Items are grou
 
 ---
 
-### ENH-003 — Hijri Calendar Events (Islamic Holidays)
+### ENH-0003 — Hijri Calendar Events (Islamic Holidays)
 **Source:** Competitor gap — 8 of 10 top apps surface Islamic calendar events  
 
 Display upcoming Islamic dates (Eid al-Fitr, Eid al-Adha, Mawlid, etc.) in the prayer times view or a dedicated calendar panel. Use `Calendar(identifier: .islamicUmmAlQura)` which is already imported.
@@ -67,7 +67,7 @@ Display upcoming Islamic dates (Eid al-Fitr, Eid al-Adha, Mawlid, etc.) in the p
 
 ## Localisation & Internationalisation
 
-### ENH-019 — App-wide Multilingual Support (i18n + l10n)
+### ENH-0019 — App-wide Multilingual Support (i18n + l10n)
 **Source:** Internal — project has been English-only since inception; see also deferred US-0016 in `RELEASE_PLAN.md`.
 **Priority:** Medium — large global Muslim audience speaks Arabic, Urdu, Indonesian, Turkish, French, Bengali, Bahasa Melayu, Persian, etc. as a first language. English-only excludes most users from a fluent UX.
 
@@ -133,7 +133,7 @@ Per-language acceptance criterion: **a native speaker has reviewed every string 
 
 ## Astronomy & Calendar
 
-### ENH-018 — Hilal Watch: Global Crescent Sighting Map ✅ Implemented (2026-05-11)
+### ENH-0018 — Hilal Watch: Global Crescent Sighting Map ✅ Implemented (2026-05-11)
 **Status:** ✅ Fully implemented — EPIC-0011 shipped in PRs #61–66. All 5 branches landed: astronomy port (Meeus/Odeh/Yallop/HMNAO), 16,200-cell grid calculator, macOS MapKit UI, iOS sheet, d29 notification. 174/174 tests passing.
 **Source:** Internal product exploration via Claude conversation (May 2026); cross-checked against moonsighting.com / OmegaHilalSighting
 **Priority:** Medium — distinctive feature; 0/10 surveyed competitors offer this
@@ -192,7 +192,7 @@ Per-language acceptance criterion: **a native speaker has reviewed every string 
 
 ## macOS-Native Enhancements
 
-### ENH-004 — macOS Menu Bar Widget / Notification Center Widget
+### ENH-0004 — macOS Menu Bar Widget / Notification Center Widget
 **Source:** Competitor gap — 7 of 10 apps have home/lock screen widgets  
 
 Add a macOS Notification Center widget (WidgetKit) showing today's prayer times and next prayer countdown. The menu bar already computes this data every 60 seconds — the widget would consume the same output.
@@ -201,7 +201,7 @@ Add a macOS Notification Center widget (WidgetKit) showing today's prayer times 
 
 ---
 
-### ENH-005 — Silent / Do Not Disturb Mode
+### ENH-0005 — Silent / Do Not Disturb Mode
 **Source:** Competitor gap — Guidance had this; users loved it; no current macOS competitor offers it  
 
 Allow the adhan sound to be suppressed globally (visual indicator only) without per-prayer muting. Distinct from the existing per-prayer mute — this is a global "I'm in a meeting" toggle accessible from the menu bar right-click menu.
@@ -210,7 +210,7 @@ Allow the adhan sound to be suppressed globally (visual indicator only) without 
 
 ---
 
-### ENH-006 — Adhan Banner Dismiss Timeout Configuration
+### ENH-0006 — Adhan Banner Dismiss Timeout Configuration
 **Source:** Internal UX  
 
 Let users set how long the adhan banner stays on screen before auto-dismissing. Currently hardcoded.
@@ -221,7 +221,7 @@ Let users set how long the adhan banner stays on screen before auto-dismissing. 
 
 ## Prayer Tracking
 
-### ENH-007 — Prayer Check-in / Habit Tracker
+### ENH-0007 — Prayer Check-in / Habit Tracker
 **Source:** Competitor gap — Just Pray (4.9★) built an entire app around this  
 
 Allow users to mark each prayer as prayed on time, prayed late, or missed. Show a simple streak counter in the main view. Store history in UserDefaults or a local SQLite database.
@@ -230,7 +230,7 @@ Allow users to mark each prayer as prayed on time, prayed late, or missed. Show 
 
 ---
 
-### ENH-008 — Sunnah Prayer Times (Tahajjud, Duha)
+### ENH-0008 — Sunnah Prayer Times (Tahajjud, Duha)
 **Source:** Competitor gap — IslamApp surfaces these  
 
 Display optional Sunnah prayer windows (Tahajjud: last third of night; Duha: 15–45 min after sunrise). These are calculated from existing Fajr/Sunrise/Dhuhr times already computed.
@@ -241,7 +241,7 @@ Display optional Sunnah prayer windows (Tahajjud: last third of night; Duha: 15�
 
 ## Qibla
 
-### ENH-009 — Augmented Reality Qibla
+### ENH-0009 — Augmented Reality Qibla
 **Source:** Competitor gap — Athan Pro offers AR Qibla  
 
 Overlay the Qibla direction on a live camera view using ARKit/RealityKit. The compass bearing is already calculated; AR adds a visual layer.
@@ -252,7 +252,7 @@ Overlay the Qibla direction on a live camera view using ARKit/RealityKit. The co
 
 ## Audio & Adhan
 
-### ENH-010 — Additional Adhan Voices
+### ENH-0010 — Additional Adhan Voices
 **Source:** Competitor feature — Namaz offers "multiple maqams from famous mosques"  
 
 Expand the adhan library beyond the current 5 regular + 3 Fajr. Potential additions: Makkah (Sheikh Sudais), Madinah, Al-Aqsa.
@@ -261,7 +261,7 @@ Expand the adhan library beyond the current 5 regular + 3 Fajr. Potential additi
 
 ---
 
-### ENH-011 — Per-Prayer Adhan Preview in Settings
+### ENH-0011 — Per-Prayer Adhan Preview in Settings
 **Source:** UX gap — users cannot audition an adhan before committing to it  
 
 Add a play/preview button next to each adhan option in the settings sheet so users can hear a short clip before selecting.
@@ -270,14 +270,14 @@ Add a play/preview button next to each adhan option in the settings sheet so use
 
 ---
 
-### ENH-023 — Adhaan Surround Mode (Spatial Multi-Muezzin)
+### ENH-0023 — Adhaan Surround Mode (Spatial Multi-Muezzin)
 **Source:** User suggestion (2026-05-21)
 **Priority:** Medium — distinctive feature; emotionally meaningful for users from Muslim-majority countries
 
 **Problem:** Iqamah plays a single adhaan at prayer time. Users who grew up in Muslim-majority countries — Egypt, Saudi Arabia, Pakistan, Indonesia, Malaysia, Turkey, the Levant — describe the experience of hearing multiple mosques start the adhaan within a 5–15 second window, each from a different direction, as one of the most emotionally evocative aspects of daily prayer life. The single-source adhaan in apps misses this sensory dimension entirely.
 
 **Solution:** "Surround Mode" that:
-1. Lets the user select 2–5 different adhaan recordings simultaneously (existing 5 regular + 3 Fajr library plus any added via ENH-010)
+1. Lets the user select 2–5 different adhaan recordings simultaneously (existing 5 regular + 3 Fajr library plus any added via ENH-0010)
 2. Plays them with staggered start times — small natural jitter (e.g. 0s / +3s / +8s / +12s) to mimic real-world multi-mosque overlap
 3. Positions each in 3D space using `AVAudioEnvironmentNode` — different azimuth/distance per source so the listener perceives mosques in different directions and at different perceived distances
 4. Master volume + per-source mix balance so overlapping playback doesn't clip
@@ -322,8 +322,8 @@ player.scheduleFile(file, at: AVAudioTime(sampleTime: offset, atRate: rate))
 - [ ] watchOS and tvOS gracefully ignore the setting (Surround Mode unavailable badge in settings)
 
 **Cross-references:**
-- ENH-010 (Additional Adhaan Voices) — synergistic; more voices = more variety
-- ENH-021 (Vision Pro Path 2) — spatial Qibla mentioned; Surround Mode is a natural pair
+- ENH-0010 (Additional Adhaan Voices) — synergistic; more voices = more variety
+- ENH-0021 (Vision Pro Path 2) — spatial Qibla mentioned; Surround Mode is a natural pair
 
 **Effort:** Medium (1–2 weeks). Audio engine code is the main lift; `AVAudioEnvironmentNode` has a learning curve but standard Apple sample code covers it.
 
@@ -334,7 +334,7 @@ player.scheduleFile(file, at: AVAudioTime(sampleTime: offset, atRate: rate))
 
 ---
 
-### ENH-024 — Adhaan Bypasses iPhone Silent Switch (Critical Alerts Entitlement)
+### ENH-0024 — Adhaan Bypasses iPhone Silent Switch (Critical Alerts Entitlement)
 **Source:** User request (2026-05-21); audit completed same day
 **Priority:** Medium-High — religiously significant; affects a substantial fraction of daily-use scenarios
 
@@ -385,7 +385,7 @@ player.scheduleFile(file, at: AVAudioTime(sampleTime: offset, atRate: rate))
 
 **Cross-references:**
 - BUG-0066 (resolved) — `.timeSensitive` interruption level for Focus / DND bypass. Silent-switch bypass is a separate (lower) layer.
-- ENH-023 (Surround Mode) — Critical Alerts grant would let Surround Mode also play through silent.
+- ENH-0023 (Surround Mode) — Critical Alerts grant would let Surround Mode also play through silent.
 
 **Effort:** Small-Medium for the code (~30 lines + Settings toggle). Large for the entitlement application — Apple's response time is days-to-weeks, may require iteration, and there's a non-zero chance of denial. Ship the code path behind a runtime entitlement check so it's ready to flip when approval arrives.
 
@@ -396,7 +396,7 @@ The audit showed Iqamah is doing everything correctly within Apple's default con
 
 ---
 
-### ENH-026 — Background-reliable Live Activity updates
+### ENH-0026 — Background-reliable Live Activity updates
 
 **Status:** Backlog
 **Source:** Follow-up from v1.6.0 LA rollover fix (PR #133, commit 405256a)
@@ -419,7 +419,7 @@ The audit showed Iqamah is doing everything correctly within Apple's default con
 
 ---
 
-### ENH-025 — Per-day Alert Scheduling
+### ENH-0025 — Per-day Alert Scheduling
 **Source:** User request (2026-05-23)
 **Priority:** Medium — quality-of-life refinement on top of existing notification system
 
@@ -443,7 +443,7 @@ The audit showed Iqamah is doing everything correctly within Apple's default con
 
 ## Content & Information
 
-### ENH-012 — Hadith of the Day
+### ENH-0012 — Hadith of the Day
 **Source:** Competitor gap — 4 of 10 apps surface a daily Hadith  
 
 Show a rotating Hadith in the main view or as a menu bar tooltip. Could be a static bundled JSON of curated Hadith to avoid network dependency.
@@ -452,7 +452,7 @@ Show a rotating Hadith in the main view or as a menu bar tooltip. Could be a sta
 
 ---
 
-### ENH-013 — Tasbih / Dhikr Counter
+### ENH-0013 — Tasbih / Dhikr Counter
 **Source:** Competitor gap — Muslim Pro and Athan have this  
 
 A simple tap counter for post-prayer dhikr. Could live as a popover from the main view.
@@ -461,7 +461,7 @@ A simple tap counter for post-prayer dhikr. Could live as a popover from the mai
 
 ---
 
-### ENH-014 — Zakat Calculator
+### ENH-0014 — Zakat Calculator
 **Source:** Competitor feature — Muslim Pro, Athan  
 
 A one-time calculator for annual Zakat based on nisab. Could be a modal or separate screen.
@@ -472,19 +472,19 @@ A one-time calculator for annual Zakat based on nisab. Could be a modal or separ
 
 ## Platform Expansion
 
-### ENH-015 — iPhone & iPad App ✅ Implemented via EPIC-0010 (2026-05-10)
+### ENH-0015 — iPhone & iPad App ✅ Implemented via EPIC-0010 (2026-05-10)
 See the multi-platform migration assessment in this file (below).
 **Status:** Implemented → EPIC-0010 (US-0040–US-0044 shipped in PRs #56–60). IqamahCore extracted, iOS target live, iCloud KVS sync, notifications, widget. US-0045 (Live Activity) deferred to v2.1.
 
-### ENH-016 — Apple Watch App ✅ Implemented via EPIC-0012 (2026-05-11)
+### ENH-0016 — Apple Watch App ✅ Implemented via EPIC-0012 (2026-05-11)
 See the multi-platform migration assessment in this file (below).
 **Status:** Implemented → EPIC-0012 (US-0053–US-0057, AC-0252–AC-0275, PR #67). Prayer times list, Qibla, settings on-watch, 4 WidgetKit complications, haptic notifications, WCSession sync.
 
-### ENH-017 — Apple Vision Pro App
-See ENH-021 below (expanded from this placeholder).
+### ENH-0017 — Apple Vision Pro App
+See ENH-0021 below (expanded from this placeholder).
 
 
-### ENH-020 — Apple TV App (tvOS)
+### ENH-0020 — Apple TV App (tvOS)
 **Source:** Product exploration — prayer times on a shared family screen; strong use case during Ramadan (Suhoor/Iftar countdowns on living-room TV)
 **Priority:** Low-Medium — niche but zero competitors offer it on tvOS
 **Release Target:** Post EPIC-0012 (Watch app must ship first; Watch Connectivity pattern established)
@@ -522,8 +522,8 @@ See ENH-021 below (expanded from this placeholder).
 
 ---
 
-### ENH-021 — Apple Vision Pro App (visionOS)
-**Source:** ENH-017 placeholder expanded
+### ENH-0021 — Apple Vision Pro App (visionOS)
+**Source:** ENH-0017 placeholder expanded
 **Priority:** Medium — "designed for iPad" path is nearly free; native path is a strong press story
 **Release Target:** Path 1 immediately after EPIC-0010 (iOS app) ships; Path 2 as optional EPIC
 
@@ -573,10 +573,10 @@ Path 2 (additional):
 
 ---
 
-### ENH-022 — Islamic Holiday Celebration Reminders
+### ENH-0022 — Islamic Holiday Celebration Reminders
 **Source:** Spawned from Fasting Mode brainstorming (2026-05-21) as a sibling concept
 
-**Problem:** Iqamah surfaces fasting practice via Fasting Mode (ENH-002) but does not commemorate non-fasting Islamic holidays. Users miss notifications for Eid al-Fitr, Eid al-Adha, Mawlid an-Nabi, Laylat al-Qadr, Hijri New Year, Ashura commemorations (Shia tradition), Isra wal-Mi'raj, Laylat al-Bara'ah, and Eid al-Ghadir (Shia).
+**Problem:** Iqamah surfaces fasting practice via Fasting Mode (ENH-0002) but does not commemorate non-fasting Islamic holidays. Users miss notifications for Eid al-Fitr, Eid al-Adha, Mawlid an-Nabi, Laylat al-Qadr, Hijri New Year, Ashura commemorations (Shia tradition), Isra wal-Mi'raj, Laylat al-Bara'ah, and Eid al-Ghadir (Shia).
 
 **Solution:** Reuse the FastingModeEngine's Hijri-date evaluation infrastructure to expose celebration notifications. Per-holiday opt-in toggles in Settings. Tradition-aware visibility (some holidays observed primarily in Shia or Sunni tradition).
 

--- a/docs/ID_REGISTRY.md
+++ b/docs/ID_REGISTRY.md
@@ -14,7 +14,7 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 | AC           | AC-0383               | AC-0382           |
 | TC           | TC-0074               | TC-0073           |
 | BUG          | BUG-0070              | BUG-0069          |
-| ENH          | ENH-027               | ENH-026           |
+| ENH          | ENH-0027               | ENH-0026           |
 
 ---
 
@@ -28,4 +28,4 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 
 ---
 
-**Last Updated:** 2026-05-24 (BUG-0069 logged — location detection cached incorrectly + no auto-detect after first run; affects iOS/macOS/watchOS.)
+**Last Updated:** 2026-05-24 (ENH IDs renumbered to ENH-XXXX format; BUG-0068 and BUG-0069 closed.)

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -50,9 +50,9 @@ Detailed release plan defining MVP and subsequent milestones. Contains Epics, Us
 
 **Status:** 🔴 Planning  
 **Candidates:**
-- ENH-001: GPS prayer time accuracy (exact coordinate + CLGeocoder timezone)
-- ENH-002: Ramadan mode (Suhoor/Iftar countdown in menu bar)
-- ENH-008: Sunnah prayer times (Tahajjud, Duha)
+- ENH-0001: GPS prayer time accuracy (exact coordinate + CLGeocoder timezone)
+- ENH-0002: Ramadan mode (Suhoor/Iftar countdown in menu bar)
+- ENH-0008: Sunnah prayer times (Tahajjud, Duha)
 - EPIC-0015 execution: XCUITest suites (US-0066–0069)
 
 ---
@@ -60,14 +60,14 @@ Detailed release plan defining MVP and subsequent milestones. Contains Epics, Us
 ### **Release 1.7 (Future)**
 
 **Status:** 🔴 Backlog  
-**Description:** Internationalisation (ENH-019) — Arabic, Urdu, Indonesian first
+**Description:** Internationalisation (ENH-0019) — Arabic, Urdu, Indonesian first
 
 ---
 
 ### **Release 2.0 (Future)**
 
 **Status:** 🔴 Backlog  
-**Description:** Apple TV (ENH-020) and/or visionOS (ENH-021) platform expansion
+**Description:** Apple TV (ENH-0020) and/or visionOS (ENH-0021) platform expansion
 
 ---
 
@@ -1255,7 +1255,7 @@ rm adhaan_4_original_backup.mp3
 
 **Description:** Add a "Hilal Watch" feature that computes and visualises global crescent visibility for the two evenings (29th and 30th of each Hijri month) on which the new Islamic month is determined. Uses the Odeh (2004) visibility criterion, validated against 737 ICOP observations, with a full Meeus lunar ephemeris (±0.01°) ported to Swift. Provides both a global map showing the characteristic S-curve visibility band and a local sighting card showing precise Odeh values (ARCL, ARCV, W, V) for the user's location.
 
-**Promoted from:** ENH-018 (see `docs/ENHANCEMENTS.md`)
+**Promoted from:** ENH-0018 (see `docs/ENHANCEMENTS.md`)
 
 **Release Target:** v1.2 ✅ Shipped
 **Status:** ✅ Implemented — PRs #61–66 (all 5 branches, 174/174 tests)
@@ -1395,7 +1395,7 @@ rm adhaan_4_original_backup.mp3
 
 **Description:** Add a native watchOS app that surfaces the next prayer time as a complication on the watch face, shows a full prayer list on-watch, and delivers a haptic tap at prayer time. Reuses `IqamahCore` for all calculation logic. Settings sync via Watch Connectivity from the iPhone companion app.
 
-**Promoted from:** ENH-016 (see `docs/ENHANCEMENTS.md`)
+**Promoted from:** ENH-0016 (see `docs/ENHANCEMENTS.md`)
 
 **Release Target:** v2.1 ✅ Shipped
 **Status:** ✅ Implemented — PR #67 (7 tests, all targets build)
@@ -1540,7 +1540,7 @@ rm adhaan_4_original_backup.mp3
 
 ---
 
-**Last Updated:** 2026-05-11 (EPIC-0010/0011/0012 all implemented. US-0040–US-0044, US-0046–US-0057 marked ✅. US-0045 deferred. ENH-020/021 added to backlog. Compass iOS-style improvements shipped PR #69.)
+**Last Updated:** 2026-05-11 (EPIC-0010/0011/0012 all implemented. US-0040–US-0044, US-0046–US-0057 marked ✅. US-0045 deferred. ENH-0020/021 added to backlog. Compass iOS-style improvements shipped PR #69.)
 
 
 ---
@@ -1689,19 +1689,19 @@ rm adhaan_4_original_backup.mp3
 
 **Total:** 49 acceptance criteria (AC-0300 – AC-0348)  
 **Estimated effort:** 7–10 developer-days  
-## EPIC-0016 — ENH-001 GPS Accuracy Finish-Up
+## EPIC-0016 — ENH-0001 GPS Accuracy Finish-Up
 
 **Status:** 🟡 Planned
 **Version Target:** v1.6
-**Cross-references:** ENH-001 in `docs/ENHANCEMENTS.md`; spec at `docs/superpowers/specs/2026-05-21-enh-001-finish-up-design.md`; plan at `docs/superpowers/plans/2026-05-21-enh-001-finish-up.md`
+**Cross-references:** ENH-0001 in `docs/ENHANCEMENTS.md`; spec at `docs/superpowers/specs/2026-05-21-enh-001-finish-up-design.md`; plan at `docs/superpowers/plans/2026-05-21-enh-001-finish-up.md`
 
-**Goal:** Close out ENH-001 by adding watchOS CLGeocoder parity (Option B), a one-time v1.6 re-detect prompt for legacy users whose `locationSource` UserDefaults key was never written (i.e. setup completed pre-ENH-001), and two structural cleanups (dead repo-root `Views/` directory deletion + watch view rename for filename disambiguation).
+**Goal:** Close out ENH-0001 by adding watchOS CLGeocoder parity (Option B), a one-time v1.6 re-detect prompt for legacy users whose `locationSource` UserDefaults key was never written (i.e. setup completed pre-ENH-0001), and two structural cleanups (dead repo-root `Views/` directory deletion + watch view rename for filename disambiguation).
 
-**Background:** ENH-001 A+B shipped during v1.5.0 across macOS first-launch, iOS first-launch, and macOS/iOS Settings re-detect. The watchOS path implemented Option A only, and legacy v1.5.0 users never had their stored timezone migrated to the authoritative value. This epic delivers parity and migration.
+**Background:** ENH-0001 A+B shipped during v1.5.0 across macOS first-launch, iOS first-launch, and macOS/iOS Settings re-detect. The watchOS path implemented Option A only, and legacy v1.5.0 users never had their stored timezone migrated to the authoritative value. This epic delivers parity and migration.
 
 ---
 
-### US-0070 — Finish ENH-001 across watchOS + Legacy Migration + Structural Cleanup
+### US-0070 — Finish ENH-0001 across watchOS + Legacy Migration + Structural Cleanup
 
 **Priority:** Medium
 **Effort:** S (½ day)
@@ -1710,10 +1710,10 @@ rm adhaan_4_original_backup.mp3
 **Acceptance Criteria:**
 
 - AC-0349: watchOS `IqamahWatchApp.locationManager(_:didUpdateLocations:)` invokes `CLGeocoder().reverseGeocodeLocation(...)` after saving raw GPS coordinates; on success writes `placemark.locality` to `SettingsManager.gpsLocality` and `placemark.timeZone?.identifier` to `SettingsManager.gpsTimezone`. CLGeocoder is short-circuited when the cached coordinate is within 5 km of the new fix and `gpsLocality` is non-empty (mirrors macOS).
-- AC-0350: On CLGeocoder failure or no network, watchOS retains the Option-A values (raw coords + `TimeZone.current`). Failure is logged with the `[ENH-001]` tag. No UI degradation.
+- AC-0350: On CLGeocoder failure or no network, watchOS retains the Option-A values (raw coords + `TimeZone.current`). Failure is logged with the `[ENH-0001]` tag. No UI degradation.
 - AC-0351: First launch of v1.6 on a device with `hasCompletedSetup && locationSource UserDefaults key absent` presents the re-detect `.alert()` exactly once on macOS and on iOS. Watch app does not present a prompt.
 - AC-0352: Either alert action sets `SettingsManager.didShowGPSReDetectPromptV16 = true`. "Keep current" also sets `locationSource = "manual"`. The alert never re-presents on subsequent launches.
-- AC-0353: `docs/ENHANCEMENTS.md` ENH-001 entry is updated to ✅ Implemented (2026-05-21) with PR references and a surface-by-surface table.
+- AC-0353: `docs/ENHANCEMENTS.md` ENH-0001 entry is updated to ✅ Implemented (2026-05-21) with PR references and a surface-by-surface table.
 - AC-0354: Repo-root `Views/` directory no longer exists; `LocationSetupView`, `CalculationMethodView`, and `SplashScreenView` exist only in their target-specific locations. Both `iqamah` and `iqamah-iOS` schemes build clean.
 - AC-0355: `IqamahWatch/WatchLocationSetupView.swift` exists; the struct is renamed to `WatchLocationSetupView`; the pbxproj path is updated; `IqamahWatchApp.swift` references the new type. `IqamahWatch` scheme builds clean.
 - AC-0356: `CLAUDE.md` contains a "Project Structure Conventions" section explaining that filenames recur across targets and pbxproj is authoritative for target membership; also documents the consolidated PrayerActivityAttributes single-source-of-truth pattern.
@@ -1724,18 +1724,18 @@ rm adhaan_4_original_backup.mp3
 
 | Story | Surfaces | Effort | AC count |
 |---|---|---|---|
-| US-0070 — Finish ENH-001 | watchOS, macOS, iOS, repo hygiene | S | 8 |
+| US-0070 — Finish ENH-0001 | watchOS, macOS, iOS, repo hygiene | S | 8 |
 
 **Total:** 8 acceptance criteria (AC-0349 – AC-0356), mapped 1:1 to TC-0036 – TC-0043.
 **Estimated effort:** ½ developer-day.
 
 ---
 
-## EPIC-0017 — Fasting Mode (ENH-002)
+## EPIC-0017 — Fasting Mode (ENH-0002)
 
 **Status:** ✅ Done
 **Version Target:** v1.6
-**Cross-references:** ENH-002 in `docs/ENHANCEMENTS.md`; spec at `docs/superpowers/specs/2026-05-21-fasting-mode-design.md`; plan at `docs/superpowers/plans/2026-05-21-fasting-mode.md`
+**Cross-references:** ENH-0002 in `docs/ENHANCEMENTS.md`; spec at `docs/superpowers/specs/2026-05-21-fasting-mode-design.md`; plan at `docs/superpowers/plans/2026-05-21-fasting-mode.md`
 
 **Goal:** Generalize Ramadan Mode into a year-round Fasting Mode covering auto-Ramadan + 7 Nawafil triggers with method-gated visibility, dedicated banner + relabel display across all surfaces, configurable Suhoor/Iftar/day-before notifications, and a new Ja'fari calculation method.
 

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -374,9 +374,9 @@ Steps:
 Expected: At most one Live Activity active for the upcoming prayer at any time
 Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 
-### EPIC-0016 — ENH-001 GPS Accuracy Finish-Up
+### EPIC-0016 — ENH-0001 GPS Accuracy Finish-Up
 
-#### US-0070 — Finish ENH-001 across watchOS + Legacy Migration + Structural Cleanup
+#### US-0070 — Finish ENH-0001 across watchOS + Legacy Migration + Structural Cleanup
 
 **TC-0036 (AC-0349) — Watch CLGeocoder refines locality and timezone**
 Type: Functional · Preconditions: Apple Watch Series 11 simulator; Custom location set to Brampton (43.685, -79.759); fresh watch app install
@@ -392,7 +392,7 @@ Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 Type: Edge Case · Preconditions: Watch app already has `gpsLocality` populated; new GPS fix within 5 km of cached coordinate
 Steps:
   1. Trigger a new location fix (e.g. tap "Update via GPS" in Settings)
-  2. Inspect debug logs for `[ENH-001]` CLGeocoder invocations
+  2. Inspect debug logs for `[ENH-0001]` CLGeocoder invocations
 Expected: No new CLGeocoder request is made; existing `gpsLocality`/`gpsTimezone` values remain unchanged
 Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 
@@ -403,7 +403,7 @@ Steps:
   2. Allow location permission
   3. Wait 5 seconds
   4. Inspect `gpsTimezone` and confirm no error UI displayed
-Expected: `gpsTimezone` equals `TimeZone.current.identifier` (Option A fallback); no alert/banner shown to user; failure logged with `[ENH-001]` tag
+Expected: `gpsTimezone` equals `TimeZone.current.identifier` (Option A fallback); no alert/banner shown to user; failure logged with `[ENH-0001]` tag
 Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 
 **TC-0039 (AC-0351, AC-0352) — Legacy v1.5 user sees prompt once on macOS v1.6**
@@ -429,7 +429,7 @@ Expected: Alert appears once; tapping "Re-detect" switches to Settings tab where
 Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 
 **TC-0041 (AC-0354) — Dead Views/ deletion does not break any build**
-Type: Regression · Preconditions: ENH-001 finish-up branch checked out
+Type: Regression · Preconditions: ENH-0001 finish-up branch checked out
 Steps:
   1. `xcodebuild -project iqamah.xcodeproj -scheme iqamah build`
   2. `xcodebuild -project iqamah.xcodeproj -scheme iqamah-iOS -destination 'platform=iOS Simulator,name=iPhone 17' build`
@@ -439,7 +439,7 @@ Expected: All three schemes report BUILD SUCCEEDED; `ls Views/` returns "No such
 Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 
 **TC-0042 (AC-0355) — Watch view rename compiles and is reachable**
-Type: Functional · Preconditions: ENH-001 finish-up branch checked out
+Type: Functional · Preconditions: ENH-0001 finish-up branch checked out
 Steps:
   1. `grep -rn "WatchLocationSetupView" IqamahWatch/`
   2. `grep -rn "struct LocationSetupView" IqamahWatch/` (should return nothing)
@@ -449,17 +449,17 @@ Expected: WatchLocationSetupView is referenced in IqamahWatchApp.swift line 30; 
 Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 
 **TC-0043 (AC-0353, AC-0356) — Documentation updated**
-Type: Functional · Preconditions: Final commit of ENH-001 finish-up branch
+Type: Functional · Preconditions: Final commit of ENH-0001 finish-up branch
 Steps:
   1. `grep "✅ Implemented (2026-05-21)" docs/ENHANCEMENTS.md`
   2. `grep "Project Structure Conventions" CLAUDE.md`
   3. `grep "AC-0356" docs/ID_REGISTRY.md`
-Expected: All three greps return at least one match; ENHANCEMENTS.md ENH-001 section includes the surface-by-surface implementation table; CLAUDE.md section explains the duplicate-filename + PrayerActivityAttributes patterns
+Expected: All three greps return at least one match; ENHANCEMENTS.md ENH-0001 section includes the surface-by-surface implementation table; CLAUDE.md section explains the duplicate-filename + PrayerActivityAttributes patterns
 Status: [ ] Not Run / [ ] Pass / [ ] Fail · Defect: None · Notes:
 
 ---
 
-### EPIC-0017 — Fasting Mode (ENH-002)
+### EPIC-0017 — Fasting Mode (ENH-0002)
 
 #### US-0071 — FastingModeEngine + settings schema
 

--- a/docs/superpowers/specs/2026-05-07-p1-p2-p3-design.md
+++ b/docs/superpowers/specs/2026-05-07-p1-p2-p3-design.md
@@ -1,7 +1,7 @@
 # Iqamah — P1/P2/P3 Design Spec
 **Date:** 2026-05-07  
 **Status:** Approved — ready for implementation planning  
-**Scope:** ENH-001, BUG-0031/32/38/39/42/45/46/50, BUG-0009 (targeted), US-0015  
+**Scope:** ENH-0001, BUG-0031/32/38/39/42/45/46/50, BUG-0009 (targeted), US-0015  
 **Preview standard:** All new UI reviewed in 4 variants — Materials Glass Light/Dark + Liquid Glass Light/Dark
 
 ---
@@ -20,7 +20,7 @@ These are mechanical changes with no ambiguity. Bundle into one commit.
 
 ---
 
-## 2. ENH-001 — GPS Exact Prayer Times
+## 2. ENH-0001 — GPS Exact Prayer Times
 
 **Problem:** Auto-detect maps GPS coordinates to the nearest city in `cities.json`, then uses that city's stored coordinates and timezone. A user in Brampton (43.685°N, 79.759°W) gets proxied to Toronto (43.653°N, 79.383°W), introducing a systematic offset on every prayer time.
 
@@ -273,7 +273,7 @@ In SwiftUI (macOS 26 target): use `.glassEffect(.regular)` inside `GlassEffectCo
 One feature branch per numbered item. Merge each to `develop` before starting the next. BUG-0009 runs last as a pass across all modified files.
 
 1. **Housekeeping** (BUG-0031/32/38/42/45) — `fix/housekeeping-p2p3` — one commit, no risk
-2. **ENH-001** — `feat/ENH-001-gps-accuracy` — self-contained service layer
+2. **ENH-0001** — `feat/ENH-0001-gps-accuracy` — self-contained service layer
 3. **BUG-0039 + mute toggle** — `fix/BUG-0039-adhaan-picker` — prayer row UI + new SettingsManager key
 4. **BUG-0050** — `fix/BUG-0050-adhaan-failure` — adhaan player + banner
 5. **BUG-0046** — `fix/BUG-0046-settings-form` — settings sheet refactor

--- a/docs/superpowers/specs/2026-05-10-hilal-watch-design.md
+++ b/docs/superpowers/specs/2026-05-10-hilal-watch-design.md
@@ -2,7 +2,7 @@
 **Date:** 2026-05-10
 **Status:** Draft — under review
 **Scope:** EPIC-0011 (US-0046 – US-0052, AC-0204 – AC-0251)
-**Promoted from:** ENH-018
+**Promoted from:** ENH-0018
 **Preview standard:** All new UI reviewed in 4 variants — Materials Glass Light/Dark + Liquid Glass Light/Dark (per `CLAUDE.md` § UI Conventions)
 
 ---
@@ -426,16 +426,16 @@ struct HilalCellRenderer {
 
 ## 12.5 Internationalisation readiness
 
-Full app-wide multilingual support is tracked separately as **ENH-019** (see `docs/ENHANCEMENTS.md`). EPIC-0011 does **not** include translations, but it must be **i18n-ready** so ENH-019 only needs to add translations, not refactor:
+Full app-wide multilingual support is tracked separately as **ENH-0019** (see `docs/ENHANCEMENTS.md`). EPIC-0011 does **not** include translations, but it must be **i18n-ready** so ENH-0019 only needs to add translations, not refactor:
 
 - Every user-visible string in Hilal Watch goes through `String(localized:)` (Swift 5.7+) — no hardcoded English `Text("…")` literals in any view.
 - Hijri month names are sourced from Foundation's `Calendar(identifier:)` localisation — no hardcoded English month names.
-- Numbers (degrees, arcminutes, V-score) are formatted via `Measurement.FormatStyle` / `Number.FormatStyle` so locale formatting is automatic when ENH-019 lands.
-- The notification body uses a parametric format string with the zone letter as `%@` — when ENH-019 lands, only the format string needs translating, not the formatting logic.
+- Numbers (degrees, arcminutes, V-score) are formatted via `Measurement.FormatStyle` / `Number.FormatStyle` so locale formatting is automatic when ENH-0019 lands.
+- The notification body uses a parametric format string with the zone letter as `%@` — when ENH-0019 lands, only the format string needs translating, not the formatting logic.
 - All horizontal layouts use SwiftUI `HStack` (which respects `Locale.LanguageDirection`) — RTL works out of the box once translations are added.
 - `MoonPhaseView` does **not** flip in RTL (astronomy is direction-neutral); the Hilal map does **not** flip (geography is fixed). Both are documented as RTL-exempt in the renderer comments.
 
-**Net effect:** when ENH-019 ships, Hilal Watch becomes multilingual with no view-layer rework — only `Localizable.xcstrings` additions and review.
+**Net effect:** when ENH-0019 ships, Hilal Watch becomes multilingual with no view-layer rework — only `Localizable.xcstrings` additions and review.
 
 ---
 
@@ -508,8 +508,8 @@ The two platform targets ideally share these files via Xcode group membership. W
 
 ## 14. Out of scope (v1)
 
-- **Apple Watch complication** — defer to a separate epic alongside the larger watchOS port (ENH-016)
-- **macOS Notification Center widget** — defer to ENH-004 (existing enhancement)
+- **Apple Watch complication** — defer to a separate epic alongside the larger watchOS port (ENH-0016)
+- **macOS Notification Center widget** — defer to ENH-0004 (existing enhancement)
 - **visionOS 3D moon volume** — premature; revisit after a v1 visionOS app exists
 - **Automated cross-reference against moonsighting.com's published maps as a CI test** — manual QA only for v1; their HTML is unstable to scrape
 - **Real-time crescent-age countdown** — the static "tonight" label is sufficient
@@ -528,7 +528,7 @@ The two platform targets ideally share these files via Xcode group membership. W
 6. **AC-0245 share dialog UI on macOS** — ✅ Resolved 2026-05-10: small pre-share dialog with the resolution toggle, then invoke `NSSharingServicePicker` with the chosen resolution.
 7. **Performance benchmark methodology** — ✅ Resolved 2026-05-10: XCTest performance test running `HilalCalculator.computeGrid` 100× on a known date in a representative criterion, measuring p50 / p95.
 8. **MapKit polygon-overlay scaling spike** — ⏳ To execute at Branch 3 kickoff. Hardware: iPhone XR (oldest accessible) for a conservative gate of ≥ 30 fps; Mobitru iPhone 12 for the AC-0217 reference gate of ≥ 50 fps. If either fails, pivot to `MKTileOverlay` (Branch 3 Task 3.7).
-9. **Arabic / multilingual rollout** — ✅ Resolved 2026-05-10: handled by ENH-019 (App-wide Multilingual Support), not in EPIC-0011 scope. EPIC-0011 only commits to being i18n-ready (§12.5).
+9. **Arabic / multilingual rollout** — ✅ Resolved 2026-05-10: handled by ENH-0019 (App-wide Multilingual Support), not in EPIC-0011 scope. EPIC-0011 only commits to being i18n-ready (§12.5).
 10. **Cell `accessibilityLabel` density** — ✅ Resolved 2026-05-10: VoiceOver labels exposed only at MapKit zoom level ≥ 4. At lower zoom levels the map view as a whole has a single summary label ("Hilal visibility map for [Month] [Year], [N] regions visible").
 
 ---
@@ -547,7 +547,7 @@ The two platform targets ideally share these files via Xcode group membership. W
 | §11 Share / export | AC-0244, 0245, 0246, 0247, 0248 |
 | §12 UI conventions | AC-0249, 0250, 0251 |
 | §12.4 Accessibility | AC-0060 – AC-0065 (existing US-0012 contract; Hilal Watch must comply) |
-| §12.5 Internationalisation readiness | (translations themselves: ENH-019) |
+| §12.5 Internationalisation readiness | (translations themselves: ENH-0019) |
 | §12.6 Error handling | implicit — no user-visible crashes or hangs |
 | §local sighting card | AC-0221, 0222, 0223, 0224, 0225 |
 

--- a/docs/superpowers/specs/2026-05-11-widgets-live-activity-design.md
+++ b/docs/superpowers/specs/2026-05-11-widgets-live-activity-design.md
@@ -1,8 +1,8 @@
 # Widgets + Live Activity Design Spec
 **Date:** 2026-05-11
 **Status:** Draft — approved for implementation planning
-**Scope:** US-0045 (Live Activity / Dynamic Island) + iOS widget expansion + macOS Notification Center widget (ENH-004)
-**Promotions from:** US-0045 (deferred from EPIC-0010), ENH-004 (macOS widget backlog)
+**Scope:** US-0045 (Live Activity / Dynamic Island) + iOS widget expansion + macOS Notification Center widget (ENH-0004)
+**Promotions from:** US-0045 (deferred from EPIC-0010), ENH-0004 (macOS widget backlog)
 
 ---
 

--- a/docs/superpowers/specs/2026-05-21-enh-001-finish-up-design.md
+++ b/docs/superpowers/specs/2026-05-21-enh-001-finish-up-design.md
@@ -1,8 +1,8 @@
-# ENH-001 Finish-Up — Design
+# ENH-0001 Finish-Up — Design
 
 **Date:** 2026-05-21
 **Status:** Draft → ready for plan
-**Tracking:** ENH-001 (docs/ENHANCEMENTS.md)
+**Tracking:** ENH-0001 (docs/ENHANCEMENTS.md)
 **Effort:** ~½ day
 **ACs:** AC-0349 – AC-0356
 
@@ -10,9 +10,9 @@
 
 ## Background
 
-ENH-001 ("Exact GPS Prayer Times via CLGeocoder, Option A+B") was largely shipped during the v1.5.0 cycle. An audit on 2026-05-21 found:
+ENH-0001 ("Exact GPS Prayer Times via CLGeocoder, Option A+B") was largely shipped during the v1.5.0 cycle. An audit on 2026-05-21 found:
 
-| Surface | ENH-001 state | Location |
+| Surface | ENH-0001 state | Location |
 |---|---|---|
 | macOS first-launch setup | ✅ A+B | `iqamah/Views/LocationSetupView.swift:142-260` |
 | iOS first-launch setup | ✅ A+B (shares macOS view via `iOSRootView.swift:103`) | same |
@@ -22,7 +22,7 @@ ENH-001 ("Exact GPS Prayer Times via CLGeocoder, Option A+B") was largely shippe
 | `SettingsManager` schema + iCloud KVS sync | ✅ Done | `Packages/IqamahCore/.../SettingsManager.swift` |
 | Tests for A+B math | ✅ Done | `Packages/IqamahCore/Tests/IqamahCoreTests/ENH001GPSTests.swift` |
 | Legacy-user migration prompt for v1.6 | ❌ Missing | — |
-| ENH-001 status in `docs/ENHANCEMENTS.md` | ❌ Still marked as planned | — |
+| ENH-0001 status in `docs/ENHANCEMENTS.md` | ❌ Still marked as planned | — |
 
 This spec covers the finish-up work plus two related structural cleanups discovered during the audit (dead duplicate files, ambiguous filenames across targets).
 
@@ -31,7 +31,7 @@ This spec covers the finish-up work plus two related structural cleanups discove
 - **GPS label persistence:** Use reverse-geocoded locality from CLGeocoder (Option B). Already implemented on macOS/iOS — extend to watchOS.
 - **Geocoder failure fallback:** Use TimeZone.current + nearest-city label (Option A values stay). Already implemented.
 - **Activation scope:** All GPS flows use the new path. Existing v1.5.0 users get a one-time prompt on v1.6 launch.
-- **Migration prompt audience:** All legacy users whose `locationSource` is unset (cannot reliably distinguish pre-ENH-001 GPS users from manual pickers; let the user decide via the prompt).
+- **Migration prompt audience:** All legacy users whose `locationSource` is unset (cannot reliably distinguish pre-ENH-0001 GPS users from manual pickers; let the user decide via the prompt).
 
 ## Scope (six items)
 
@@ -43,11 +43,11 @@ Add CLGeocoder reverse-geocode to the two watch GPS entry points so the watch ma
 
 **`IqamahWatch/SettingsTab.swift`** — the "Update via GPS" button currently re-runs the same location-manager path; once `IqamahWatchApp` is fixed it inherits the refinement automatically. Verify no separate code path here; add a watchOS-targeted unit test that exercises the refinement.
 
-**Behaviour on failure:** Option A values remain in place (raw coords + TimeZone.current). Log `[ENH-001]` and exit. Matches macOS pattern at `LocationSetupView.swift:240-242`.
+**Behaviour on failure:** Option A values remain in place (raw coords + TimeZone.current). Log `[ENH-0001]` and exit. Matches macOS pattern at `LocationSetupView.swift:240-242`.
 
 ### 2. One-time v1.6 re-detect prompt
 
-Prompt legacy users (whose `locationSource` is unset because they completed setup before ENH-001 schema landed) once on first launch of v1.6.
+Prompt legacy users (whose `locationSource` is unset because they completed setup before ENH-0001 schema landed) once on first launch of v1.6.
 
 **New `SettingsManager` key:**
 ```swift
@@ -76,7 +76,7 @@ hasCompletedSetup == true
 
 ### 3. Doc closeout
 
-- `docs/ENHANCEMENTS.md` — update ENH-001 heading to `✅ Implemented (2026-05-21)`, list which surfaces ship A vs A+B, link the v1.6 PR.
+- `docs/ENHANCEMENTS.md` — update ENH-0001 heading to `✅ Implemented (2026-05-21)`, list which surfaces ship A vs A+B, link the v1.6 PR.
 - `docs/ID_REGISTRY.md` — bump `AC` next-available to AC-0357 after the AC-0349 – AC-0356 in this spec are consumed.
 - No new EPIC/US/ENH/BUG IDs needed.
 
@@ -131,10 +131,10 @@ not the repo root.
 ## Acceptance criteria
 
 - **AC-0349:** watchOS `IqamahWatchApp.locationManager(_:didUpdateLocations:)` invokes `CLGeocoder().reverseGeocodeLocation(...)` after saving raw GPS coordinates; on success, writes `placemark.locality` to `SettingsManager.gpsLocality` and `placemark.timeZone?.identifier` to `SettingsManager.gpsTimezone`. CLGeocoder is short-circuited when the cached coordinate is within 5 km of the new fix and `gpsLocality` is non-empty (mirrors macOS).
-- **AC-0350:** On CLGeocoder failure or no network, watchOS retains the Option-A values (raw coords + `TimeZone.current`). No UI degradation or error surfaced to the user. Failure is logged with the `[ENH-001]` tag.
+- **AC-0350:** On CLGeocoder failure or no network, watchOS retains the Option-A values (raw coords + `TimeZone.current`). No UI degradation or error surfaced to the user. Failure is logged with the `[ENH-0001]` tag.
 - **AC-0351:** First launch of v1.6 on a device with `hasCompletedSetup && locationSource.isEmpty` presents the re-detect `.alert()` exactly once on macOS and on iOS. Watch app does not present a prompt.
 - **AC-0352:** Either alert action sets `SettingsManager.didShowGPSReDetectPromptV16 = true`. "Keep current" also sets `locationSource = "manual"`. The alert never re-presents on subsequent launches.
-- **AC-0353:** `docs/ENHANCEMENTS.md` ENH-001 entry is updated to ✅ Implemented (2026-05-21) with PR references and a surface-by-surface table.
+- **AC-0353:** `docs/ENHANCEMENTS.md` ENH-0001 entry is updated to ✅ Implemented (2026-05-21) with PR references and a surface-by-surface table.
 - **AC-0354:** Repo-root `Views/` directory no longer exists; `LocationSetupView`, `CalculationMethodView`, and `SplashScreenView` exist only in their target-specific locations. Both `iqamah` and `iqamah-iOS` schemes build clean.
 - **AC-0355:** `IqamahWatch/WatchLocationSetupView.swift` exists; the struct is renamed to `WatchLocationSetupView`; the pbxproj path is updated; `IqamahWatchApp.swift` references the new type. `IqamahWatch` scheme builds clean.
 - **AC-0356:** `CLAUDE.md` contains a "Project Structure Conventions" section explaining that filenames recur across targets and pbxproj is authoritative for target membership.
@@ -152,6 +152,6 @@ not the repo root.
 | `Packages/IqamahCore/Tests/IqamahCoreTests/ENH001GPSTests.swift` | Add two new tests |
 | `iqamah.xcodeproj/project.pbxproj` | Update path for `WA000000000000000000011R` |
 | `Views/` (repo root) | Delete entire directory (3 files) |
-| `docs/ENHANCEMENTS.md` | Mark ENH-001 ✅ |
+| `docs/ENHANCEMENTS.md` | Mark ENH-0001 ✅ |
 | `docs/ID_REGISTRY.md` | Bump AC counter to AC-0357 |
 | `CLAUDE.md` | Add Project Structure Conventions section |

--- a/docs/superpowers/specs/2026-05-21-fasting-mode-design.md
+++ b/docs/superpowers/specs/2026-05-21-fasting-mode-design.md
@@ -1,8 +1,8 @@
-# Fasting Mode (ENH-002) — Design
+# Fasting Mode (ENH-0002) — Design
 
 **Date:** 2026-05-21
 **Status:** Draft → ready for plan
-**Tracking:** ENH-002 (docs/ENHANCEMENTS.md) — expanded from "Ramadan Mode" to generalized "Fasting Mode"
+**Tracking:** ENH-0002 (docs/ENHANCEMENTS.md) — expanded from "Ramadan Mode" to generalized "Fasting Mode"
 **Effort:** Medium (~2–3 weeks development + 1 week QA across all surfaces)
 **Promotion target:** EPIC-0017 / US-0071–US-0075 / AC-0357–AC-0382 / TC-0044–TC-0069
 
@@ -10,7 +10,7 @@
 
 ## Background
 
-ENH-002 was originally specced as "Ramadan Mode (Suhoor & Iftar Countdowns)" — auto-detect Ramadan via Hijri calendar and show Suhoor/Iftar countdowns in the macOS menu bar and iOS header. During brainstorming on 2026-05-21 the scope generalized significantly:
+ENH-0002 was originally specced as "Ramadan Mode (Suhoor & Iftar Countdowns)" — auto-detect Ramadan via Hijri calendar and show Suhoor/Iftar countdowns in the macOS menu bar and iOS header. During brainstorming on 2026-05-21 the scope generalized significantly:
 
 - Renamed to **Fasting Mode** to cover both Ramadan and year-round Nawafil (supererogatory) fasts
 - Activation expanded from "auto-Ramadan" to a set of nine independently-toggleable triggers covering the canonical Sunnah fasting days from authentic hadith
@@ -28,7 +28,7 @@ ENH-002 was originally specced as "Ramadan Mode (Suhoor & Iftar Countdowns)" —
 
 ## Out of scope (deferred to future ENHs)
 
-- **Celebration reminders for Islamic holidays** (Eid al-Fitr, Eid al-Adha, Mawlid, Laylat al-Qadr, Hijri new year, Ashura commemorations) — distinct concept from fasting; tracked as a new ENH-022 stub in `docs/ENHANCEMENTS.md`
+- **Celebration reminders for Islamic holidays** (Eid al-Fitr, Eid al-Adha, Mawlid, Laylat al-Qadr, Hijri new year, Ashura commemorations) — distinct concept from fasting; tracked as a new ENH-0022 stub in `docs/ENHANCEMENTS.md`
 - **Customizable 6-of-Shawwal day selection** — v1 picks 2–7 Shawwal automatically (Eid is day 1, always excluded). A future enhancement could let users pick any 6 days in Shawwal
 - **"Most of Sha'ban" trigger** — the hadith says "most of" without a specific date range. Users can use the weekly schedule to cover Sha'ban Mondays/Thursdays; auto-triggering an arbitrary date range overreaches
 - **Per-prayer Maghrib delay tuning for Ja'fari users** — the Ja'fari calculation method's encoded Maghrib delay is sufficient; manual offsets are already available via the existing `prayerAdjustments` system
@@ -488,7 +488,7 @@ Plus existing `calculationMethod` (already KVS-synced) gains `.jafari` as a vali
 `settings.hijriDayOffset` (already in SettingsManager) is applied to date inputs before trigger evaluation. Tests cover offset = ±1 across Ramadan/Eid boundaries.
 
 ### Timezone changes
-Engine takes `TimeZone` as a parameter; uses `settings.activeTimezoneIdentifier` (from ENH-001). A traveler crossing midnight in their original timezone sees the new day's fasting state at the moment of crossover.
+Engine takes `TimeZone` as a parameter; uses `settings.activeTimezoneIdentifier` (from ENH-0001). A traveler crossing midnight in their original timezone sees the new day's fasting state at the moment of crossover.
 
 ### Midnight rollover
 Each render call passes `Date()`, so the answer naturally updates after midnight. The menu bar / iOS hero are timer-driven (re-render every 60 s) — they'll pick up the new state within one tick. Notifications are re-scheduled at midnight by the existing AppDelegate / NotificationScheduler midnight handlers.
@@ -601,7 +601,7 @@ All trigger logic, exclusion filtering, label formatting, and notification plann
 
 ## EPIC / US / AC / TC Promotion
 
-### EPIC-0017 — Fasting Mode (ENH-002)
+### EPIC-0017 — Fasting Mode (ENH-0002)
 
 **Status:** 🟡 Planned
 **Version Target:** v1.6
@@ -690,7 +690,7 @@ Add the `.jafari` case and the `isShiaMethod` helper that drives tradition gatin
 
 ### ID Registry consumption
 
-After ENH-001 finish-up consumes through AC-0356 and TC-0043, ENH-002 will consume:
+After ENH-0001 finish-up consumes through AC-0356 and TC-0043, ENH-0002 will consume:
 
 | Sequence | First | Last | Count |
 |---|---|---|---|
@@ -707,7 +707,7 @@ Post-implementation `ID_REGISTRY.md` next-available values:
 | US | US-0076 |
 | AC | AC-0383 |
 | TC | TC-0074 |
-| ENH | ENH-023 (ENH-022 stub for celebration reminders added to `docs/ENHANCEMENTS.md` during this work) |
+| ENH | ENH-0023 (ENH-0022 stub for celebration reminders added to `docs/ENHANCEMENTS.md` during this work) |
 
 ---
 
@@ -751,7 +751,7 @@ Post-implementation `ID_REGISTRY.md` next-available values:
 | `IqamahLiveActivity/PrayerLiveActivityView.swift` | Apply relabel |
 | `iqamah/iOS/PrayerActivityManager.swift` | Pass fasting state into ContentState |
 | `iqamah.xcodeproj/project.pbxproj` | Add new file refs + multi-target memberships for FastingBanner + FastingModeSection |
-| `docs/ENHANCEMENTS.md` | Mark ENH-002 ✅; add ENH-022 stub for celebration reminders |
+| `docs/ENHANCEMENTS.md` | Mark ENH-0002 ✅; add ENH-0022 stub for celebration reminders |
 | `docs/RELEASE_PLAN.md` | Add EPIC-0017 + US-0071–US-0075 + AC-0357–AC-0382 |
 | `docs/TEST_CASES.md` | Add TC-0044 — TC-0073 |
 | `docs/ID_REGISTRY.md` | Bump EPIC→0018, US→0076, AC→0383, TC→0074, ENH→0023 |
@@ -760,11 +760,11 @@ Post-implementation `ID_REGISTRY.md` next-available values:
 
 ## Cross-References
 
-- **ENH-002** (this work) supersedes the original Ramadan Mode stub in `docs/ENHANCEMENTS.md`
-- **ENH-022** (Celebration reminders) — new stub to be added during this work
-- **ENH-023** is next available after this spec lands
+- **ENH-0002** (this work) supersedes the original Ramadan Mode stub in `docs/ENHANCEMENTS.md`
+- **ENH-0022** (Celebration reminders) — new stub to be added during this work
+- **ENH-0023** is next available after this spec lands
 - **EPIC-0015** (Test Automation) — once US-0065 (snapshot tests) ships, the FastingBanner snapshot suite slots in naturally
-- **ENH-001** (GPS Accuracy) — already-shipped + finish-up spec. ENH-001's `gpsTimezone` is consumed via `settings.activeTimezoneIdentifier` for engine evaluation
+- **ENH-0001** (GPS Accuracy) — already-shipped + finish-up spec. ENH-0001's `gpsTimezone` is consumed via `settings.activeTimezoneIdentifier` for engine evaluation
 - **`IqamahLiveActivity/PrayerActivityAttributes.swift` consolidation** — completed 2026-05-21 (commit `c5215bd`); the optional Fasting Mode fields are added to the single canonical file with multi-target membership
 
 ---
@@ -780,4 +780,4 @@ Post-implementation `ID_REGISTRY.md` next-available values:
 - ID consumption is explicit (EPIC-0017, US-0071–0075, AC-0357–0382, TC-0044–0073)
 - Visual treatments specified with exact gradient hex values and glyphs
 - Notification cap calculation done explicitly (21 + 35 = 56 < 64)
-- Out-of-scope items called out (celebrations as ENH-022; "most of Sha'ban" deferred)
+- Out-of-scope items called out (celebrations as ENH-0022; "most of Sha'ban" deferred)


### PR DESCRIPTION
## Summary

Doc-only cleanup PR. Three logical changes:

1. **Close BUG-0068** — Watch app icon fix accepted by App Store in v1.5 (15). Moved from Open to Resolved; updated status; refreshed top-of-doc summary.
2. **Close BUG-0069** — Location detection fix shipped in PR #140 (commit 860b028). Moved from Open to Resolved.
3. **Renumber ENH-XXX → ENH-XXXX** — All other ID sequences (BUG, EPIC, US, AC, TC, TASK) use 4-digit format. ENH was the lone 3-digit outlier. Renamed 26 IDs (ENH-001 → ENH-0001 ... ENH-026 → ENH-0026) across canonical docs. Skipped frozen plan files under `docs/superpowers/plans/` per CLAUDE.md guidance.

## Files touched (10)

- `docs/BUGS.md`
- `docs/ENHANCEMENTS.md`
- `docs/ID_REGISTRY.md`
- `docs/RELEASE_PLAN.md`
- `docs/TEST_CASES.md`
- `docs/superpowers/specs/2026-05-07-p1-p2-p3-design.md`
- `docs/superpowers/specs/2026-05-10-hilal-watch-design.md`
- `docs/superpowers/specs/2026-05-11-widgets-live-activity-design.md`
- `docs/superpowers/specs/2026-05-21-enh-001-finish-up-design.md`
- `docs/superpowers/specs/2026-05-21-fasting-mode-design.md`

## Test plan

- [x] `git diff --stat origin/main..HEAD` — only `docs/` files touched, no code
- [x] `grep -rn "ENH-[0-9]\{3\}[^0-9]" docs/{ENHANCEMENTS,ID_REGISTRY,RELEASE_PLAN,BUGS,TEST_CASES}.md docs/superpowers/specs/` — zero 3-digit ENH refs remain in canonical docs
- [x] `grep -nE "BUG-006[89].*Open" docs/BUGS.md` — zero (both closed)
- [x] ENH-ref count in ENHANCEMENTS.md unchanged before/after rename (39 → 39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)