### PR TITLE
docs: v1.6.0 release notes + ENH-0026 design spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ The test suite covers prayer calculation accuracy, city model validation, Qiblah
 
 ---
 
+## Known Limitations
+
+- **Live Activity drift on long-suspended app (iOS)**: if iOS suspends the Iqamah app for several hours, the Dynamic Island Live Activity may briefly show a passed prayer until the app is reopened. Notifications are unaffected. Tracked as [ENH-0026](docs/ENHANCEMENTS.md#enh-0026); see [v1.6.0 release notes](docs/RELEASE_NOTES_v1.6.0.md#known-limitations) for the user-facing workaround.
+
+---
+
 ## Contributing
 
 1. Fork the repo and create a branch from `develop`

--- a/docs/ENHANCEMENTS.md
+++ b/docs/ENHANCEMENTS.md
@@ -396,26 +396,27 @@ The audit showed Iqamah is doing everything correctly within Apple's default con
 
 ---
 
-### ENH-0026 — Background-reliable Live Activity updates
+### ENH-0026 — Background-reliable Live Activity + push-driven notifications
 
-**Status:** Backlog
-**Source:** Follow-up from v1.6.0 LA rollover fix (PR #133, commit 405256a)
+**Status:** Future enhancement (backend infrastructure required)
+**Source:** Follow-up from v1.6.0 LA rollover fix (PR #133)
+**Design spec:** [docs/superpowers/specs/2026-05-24-enh-0026-push-driven-notifications-design.md](superpowers/specs/2026-05-24-enh-0026-push-driven-notifications-design.md)
+**Last reviewed:** 2026-05-24 (design brainstorm completed; implementation deferred)
 
-**Problem:** v1.6.0 ships a foreground/recent-background fix for the Live Activity "stuck on passed prayer" bug — `staleDate` + a `Timer` that re-evaluates the activity state at the next prayer time. If the app is suspended (long-backgrounded, terminated, or memory-pressured), the Timer doesn't fire and the Live Activity / Dynamic Island can drift again until the user reopens the app.
+**Problem.** PR #133's foreground `Timer` + `staleDate` fix covers Live Activity rollover for foreground/recent-background iOS apps. Fully suspended apps still drift until reopened. Full fix requires push-driven updates from a backend that calls APNs HTTP/2 on schedule.
 
-**Proposed solution:** Move from local Activity updates to push-token Live Activities. Each scheduled prayer time becomes a server-pushed `ActivityContent` update via APNs (or a silent local APNs via `Activity<...>.pushToken` if Apple's documentation allows it without a server). Pair with `BGAppRefreshTask` registration so the app can re-arm the next push window on launch / background refresh.
+**Designed solution (parked).** Cloudflare Workers production + local Mac for staging. Devices register settings to CloudKit; backend polls CloudKit every 15 min and on opportunistic LAN POSTs, computes the notification queue, sends APNs pushes. Live Activity updates pushed every 60s when `ContentState` changes. Full detail in the design spec.
 
-**Why backlog (not Epic yet):**
-- Requires a backend (or commitment to a server-light solution like a cheap Cloudflare Worker / Lambda) — design + cost decision.
-- Push payload format + retry strategy needs design.
-- Existing code already produces a `FastingDayState` per evaluation — pure-data side already done.
+**Why deferred:**
 
-**Promotion criteria:** Promote to EPIC + US when the team commits to a notification backend (a separate decision the indie/solo dev cycle will gate on).
+- Requires committing to backend operations (cost, SLA, monitoring) — shift from current client-only identity.
+- ~$5–$10/mo at 100k MAU is the minimum credible cost.
+- Privacy / GDPR implications when settings + location flow through developer infrastructure.
+- ENH-0027 (cross-ecosystem expansion) may change infrastructure decisions.
 
-**References:**
-- `iqamah/iOS/PrayerActivityManager.swift` — current foreground Timer
-- `IqamahLiveActivity/PrayerActivityAttributes.swift` — ContentState struct
-- Apple docs: ActivityKit push-token updates
+**Promotion criteria:** Product decision to commit to backend ops + privacy review + funding model agreed.
+
+**v1.6.0 workaround for end users:** Open Iqamah briefly to refresh the LA. Documented in `RELEASE_NOTES_v1.6.0.md` known limitations.
 
 ---
 

--- a/docs/RELEASE_NOTES_v1.6.0.md
+++ b/docs/RELEASE_NOTES_v1.6.0.md
@@ -1,0 +1,150 @@
+# Iqamah v1.6.0 Release Notes
+
+**Release date:** 2026-XX-XX (TBD when submitted)
+**Build:** 15
+**Platforms:** macOS 14+, iOS 17+, watchOS 26+
+
+## 🌟 New in this release
+
+### Fasting Mode (EPIC-0017)
+
+Comprehensive support for Islamic fasting traditions — automatic Ramadan, weekly Sunnah days, Hijri-anchored special days, and Shia-specific observances. All Sunni and Shia methods supported. A single pure-functional `FastingModeEngine` in `IqamahCore` decides "is today a fasting day" and feeds every glanceable surface (menu bar, popover, iOS hero card, watch, widgets, Live Activity).
+
+**Triggers (9, independently toggleable):**
+
+- `autoRamadan` — automatic Ramadan detection from the Hijri calendar
+- `weeklySchedule` — Monday and/or Thursday weekly Sunnah
+- `ayyamAlBeed` — 13/14/15 of every Hijri month ("white days")
+- `sixDaysShawwal` — 2–7 Shawwal (six days following Eid al-Fitr)
+- `dayOfArafah` — 9 Dhul-Hijjah
+- `firstNineDhulHijjah` — 1–9 Dhul-Hijjah
+- `muharramFast` — Tasu'a (Shia) / Ashura 9+10 Muharram (Sunni)
+- `midShaban` — 15 Sha'ban (method-gated to Shia)
+- `mabath` — 27 Rajab (method-gated to Shia)
+
+**Prohibitions (5, hard-suppress mode at runtime):**
+
+- `eidAlFitr` (1 Shawwal)
+- `eidAlAdha` (10 Dhul-Hijjah)
+- `tashriq11`, `tashriq12`, `tashriq13` (11/12/13 Dhul-Hijjah)
+
+**Notifications:** Suhoor reminder (configurable 5–120 min lead), Iftar reminder (configurable 5–120 min lead, separate setting), optional day-before reminder at a user-picked time. Day-before is suppressed for Ramadan days 2–30 to avoid noise.
+
+**UI:** Live banner on the macOS popover, iOS hero card with 🌙 + purple gradient (Ramadan) or 🕗 + teal gradient (Nawafil), watchOS prayer-tab indicator, widget labelling, Live Activity treatment.
+
+**Settings:** Full configuration UI on macOS and iOS (master toggle, per-trigger toggles, lead-time pickers, calculation-method-gated visibility for Shia-emphasis triggers). Simpler master toggle on watchOS.
+
+Shipped across PRs #132 (foundation), #136 (UI wiring), #137 (settings UI), #138 (schedulers + close-out), #139 (snapshot coverage).
+
+### Better location detection (BUG-0069 fix)
+
+- **"Current Location" row** at the top of city pickers showing your actual geocoded locality.
+- **Pre-resolved geocoder** so the picker shows e.g. "Airdrie" instead of snapping to "Calgary" purely by nearest-city distance.
+- **Opt-in 25 km auto-detect** — prompts to switch cities when you've moved more than 25 km from your saved city. Off by default; new `autoDetectOnMove` setting.
+
+Shipped in PR #140.
+
+### Live Activity / Dynamic Island fixes
+
+- Live Activity now advances past a passed prayer when the app is foregrounded or recently backgrounded (PR #133 — foreground `Timer` re-evaluates `ContentState` at the next prayer boundary).
+- `staleDate` set so iOS dims the Live Activity after a prayer passes rather than showing a "live" stale time.
+
+### macOS polish
+
+- **Start on Login** toggle now surfaces actual error messages from `SMAppService` (PR #133) instead of failing silently.
+- Top-bar buttons (Qiblah, Settings, About, Mute) now have labels and better spacing.
+- iOS CFBundleVersion uses the `CURRENT_PROJECT_VERSION` build-setting substitution so the App Store version-validation gate works correctly across all targets (PR #134).
+
+### Developer-facing improvements
+
+- **272 IqamahCore tests** (up from 251 at v1.5.0) — Fasting Mode adds `FastingModeEngineTests`, `FastingModeTypesTests`, `FastingLabelFormatterTests`, `FastingNotificationPlannerTests`, and `FastingModeSettingsCodecTests`.
+- **23 snapshot tests** (up from 9) — now covering `FastingBanner`, `FastingModeSection` settings UI, and the prior macOS / iOS / widget surfaces.
+- **ENH IDs renumbered to ENH-XXXX** four-digit format (matches `BUG-XXXX`, `EPIC-XXXX`, etc.) — closed in PR #141.
+- **BUG-0068** (App Store rejection of v1.5 (13) watch icon) and **BUG-0069** (location detect / city picker) closed.
+
+## ⚠️ Known limitations
+
+### Live Activity may drift if app is fully suspended
+
+Iqamah's Live Activity / Dynamic Island (iOS) shows your next prayer and updates automatically when the app is open or recently backgrounded. If iOS suspends the app for an extended period (memory pressure, device restart, or several hours of background time), the Live Activity may briefly show a passed prayer until you reopen the app, at which point it refreshes within ~2 seconds.
+
+This is a known limitation of client-only Live Activity updates. A full fix requires push-driven updates via backend infrastructure — tracked as [ENH-0026](ENHANCEMENTS.md#enh-0026) (design spec at [2026-05-24-enh-0026-push-driven-notifications-design.md](superpowers/specs/2026-05-24-enh-0026-push-driven-notifications-design.md)) and planned for a future release.
+
+**Workaround:** open Iqamah briefly to refresh the Live Activity. The prayer-time notifications themselves (Adhan, Suhoor reminder, Iftar reminder) are unaffected and continue to fire reliably from local scheduling.
+
+## 🛠 Changes by area
+
+### Core (`IqamahCore`)
+
+- `feat(core): Fasting Mode foundation (Tasks 1–9 of EPIC-0017)` — PR #132
+- `refactor(activitykit): consolidate PrayerActivityAttributes into single source`
+
+### iOS
+
+- `feat(ui): Fasting Mode UI wiring (Tasks 10–14 of EPIC-0017)` — PR #136
+- `feat(ui): Fasting Mode settings UI (Tasks 15–16 of EPIC-0017)` — PR #137
+- `feat(ios): v1.6 re-detect prompt for legacy users (AC-0351, AC-0352)`
+- `fix(BUG-0069): show detected city in picker + opt-in 25km auto-detect` — PR #140
+- `fix(ios): use CURRENT_PROJECT_VERSION substitution for CFBundleVersion` — PR #134
+- `fix(ios): migrate Activity.end to iOS 16.2+ signature`
+- `chore(ios): drop redundant openSettingsForReDetect notification post`
+
+### macOS
+
+- `fix(v1.6.0): LA rollover, Start-on-Login errors, macOS toolbar polish, ENH-025` — PR #133
+- `feat(macos): v1.6 re-detect prompt for legacy users (AC-0351, AC-0352)`
+- `refactor(macos): use applyGeocodingRefinement helper in LocationSetupView`
+
+### watchOS
+
+- `feat(watch): add CLGeocoder refinement after GPS detect (ENH-001 Option B parity)`
+- `refactor(watch): rename LocationSetupView to WatchLocationSetupView`
+- `fix(watch): drop non-Sendable settings capture in CLGeocoder Task closure`
+- `fix(watch-icon): WatchAppIconView with 3 design variants for BUG-0068`
+- `fix(watch-icon): replace asset with variant B (lighter navy) — BUG-0068`
+- `fix(watch-icon): reset PNG DPI to 72 (BUG-0068 follow-up)`
+- `fix(icon-export): emit PNGs at 72 DPI via ImageRenderer instead of NSHostingView`
+
+### Notifications / Live Activity / Widgets
+
+- `feat(notifications): Fasting Mode schedulers + EPIC-0017 close-out (Tasks 17–21)` — PR #138
+
+### Settings
+
+- `feat(settings): add v1.6 re-detect prompt flag + legacy-user detection`
+- `feat(ux): highlight Detect-location button after v1.6 legacy GPS prompt`
+
+### Tooling / CI / cleanup
+
+- `tooling: CLI watch-icon exporter + IconExporterView UI for BUG-0068`
+- `chore: gate icon-export dev tooling behind #if DEBUG`
+- `chore: bump build number to 14 across all targets`
+- `chore: delete dead repo-root Views/ directory`
+- `style: fix SwiftFormat indentation + remove force-unwrap (CI unblocker)`
+
+### Tests
+
+- `test(snapshots): add FastingBanner + FastingModeSection visual regression` — PR #139
+
+### Docs
+
+- `docs: design spec for Fasting Mode (ENH-002 expanded)`
+- `docs: implementation plan for Fasting Mode (ENH-002 / EPIC-0017)`
+- `docs(plan): expand Tasks 10-21 to full TDD detail for Fasting Mode`
+- `docs(fasting-mode): finalize Sunni Muharram label as 'Ashura (9+10 Muharram)'`
+- `docs: design spec for ENH-001 finish-up (watch parity + v1.6 prompt + cleanup)`
+- `docs: implementation plan for ENH-001 finish-up`
+- `docs: ENH-001 closeout + CLAUDE.md project structure note`
+- `docs: promote ENH-001 finish-up to EPIC-0016 + add TC-0036-0043`
+- `docs(bugs): log BUG-0068 — App Store rejection of v1.5 (13) watch icon`
+- `docs(enhancements): add ENH-023 Adhaan Surround Mode + ENH-024 silent-switch bypass check`
+- `docs(enhancements): expand ENH-024 with audit findings`
+- `docs: log ENH-026 background LA + clarify iOS xcodebuild scheme` — PR #135
+- `docs: log ENH-0027 — Cross-Ecosystem Expansion (Windows/Linux/Android)` — PR #144
+- `docs: close BUG-0068/BUG-0069 + renumber ENH IDs to 4-digit format` — PR #141
+
+## Migration notes
+
+- `FastingModeSettings` is forward-compatible via a custom `Codable init(from:)` — no migration required from v1.5.x.
+- iCloud KVS keys unchanged for existing settings; new `fastingModeSettings` and `autoDetectOnMove` keys added.
+- App Store version is **15**; any TestFlight build below 15 will be replaced on upload.

--- a/docs/superpowers/specs/2026-05-24-enh-0026-push-driven-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-24-enh-0026-push-driven-notifications-design.md
@@ -1,0 +1,228 @@
+# ENH-0026 — Push-Driven Notifications & Background-Reliable Live Activity (Design)
+
+**Date:** 2026-05-24
+**Status:** Design captured → implementation deferred (parked)
+**Tracking:** ENH-0026 (docs/ENHANCEMENTS.md)
+**Effort estimate (if promoted):** Large (~4–6 weeks first-cut: backend bring-up + Worker port + APNs auth + client registration + privacy review)
+
+---
+
+## 1. Problem statement
+
+PR #133 (commit `405256a`) shipped a foreground-Timer + `staleDate` fix that keeps the Live Activity / Dynamic Island honest while the iOS app is foregrounded or recently backgrounded — the Timer re-evaluates `ContentState` at the next prayer boundary and `staleDate` lets iOS dim the activity once the time has passed. That fix does not cover the fully-suspended case: if iOS suspends Iqamah for several hours (memory pressure, device restart, prolonged background), no Timer fires, no local update is scheduled, and the Live Activity drifts on a passed prayer until the user reopens the app. ENH-0026 designs the path to push-driven updates that work regardless of app suspension state.
+
+## 2. Scope
+
+This design treats **all time-sensitive notifications** — prayer reminders, Fasting Mode Suhoor / Iftar / day-before reminders, and Live Activity content updates — as push-driven from a backend that talks APNs HTTP/2. Local `UNUserNotificationCenter` scheduling and local `Activity.update(...)` calls are retired for these flows, removing a meaningful chunk of per-platform scheduling code and the brittleness that comes with it.
+
+Two ruled-out alternatives are explicitly noted so we don't relitigate them: **CloudKit Functions** (does not exist as a shipped Apple product), and **Synology / home NAS in production** (single home internet pipe cannot reliably reach 100k+ App Store users; fine for staging only). The chosen split is Cloudflare Workers in production and a local-Mac Swift container for staging.
+
+## 3. Final architecture: Cloudflare Workers + local Mac for staging
+
+### Production — Cloudflare Workers
+
+- Workers + Workers KV + Cron Triggers. Free tier covers ~10k MAU; ~$5–$10/month at 100k MAU.
+- Worker code is **TypeScript** (one-time port of `FastingNotificationPlanner` + `PrayerCalculator` from Swift). Both are pure functions over inputs already well-tested in `IqamahCoreTests` — the port has a high-confidence test oracle.
+- Three logical handlers (one Worker or three, both viable):
+  - **Scheduler** (cron) — recomputes notification queue per device.
+  - **Sender** (cron) — drains the queue against APNs.
+  - **LA Pusher** (cron) — recomputes Live Activity `ContentState` and pushes deltas.
+- **Workers KV** holds: `DeviceRegistration` cache, `NotificationPlan` queue, `LiveActivityRegistration` cache, error log.
+- APNs HTTP/2 from the Worker via `fetch()` with JWT bearer auth from the `.p8` signing key (stored as a Worker secret).
+
+### Staging — local Mac, no NAS required
+
+- Same architecture in a Swift-on-Linux container running on the developer's Mac via Docker Desktop.
+- Reuses `IqamahCore` directly as a vendored SPM dependency — staging and the app share a single source of truth for prayer math, with Workers TS as the production port we periodically diff-check against the Swift oracle.
+- Validates the end-to-end push flow against a dev CloudKit container before flipping production.
+- Stack: **Hummingbird 2** (HTTP server for admin UI), **APNSwift** (APNs HTTP/2 client), **AsyncHTTPClient** (CloudKit REST), **SQLiteNIO** (queue persistence).
+- No auth on the admin UI — LAN-trust is fine for the developer's home network. Retrofit hook is present so a single bearer-token check can be added later without refactoring routes.
+
+## 4. Data model
+
+### 4a. CloudKit records (private DB, per-user)
+
+**`DeviceRegistration`** — one record per device install.
+
+- `recordName`: UUID generated on first launch, persisted in Keychain (survives reinstall iff Keychain entry isn't wiped).
+- `pushToken` (String, APNs hex), `platform` (String — `"ios" | "macos" | "watchos"`), `bundleID` (String).
+- City fields: `cityName`, `countryCode`, `latitude`, `longitude`, `timezoneIdentifier`.
+- `calculationMethod` (String, raw enum value), `asrMethod` (String).
+- `prayerAdjustmentsJSON` (String, encoded `[Prayer: Int]`).
+- `fastingSettingsJSON` (String, `FastingModeSettings` blob).
+- `locale` (String, e.g. `"en-CA"`).
+- `lastSeenAt` (Date), `schemaVersion` (Int64, start at `1`).
+
+**`LiveActivityRegistration`** — one record per active Live Activity.
+
+- `recordName`: `Activity.id` UUID.
+- `deviceRef` (Reference to `DeviceRegistration`, cascade delete).
+- `pushToken` (String, LA-specific token — different from the device token).
+- `attributesJSON` (String, `PrayerActivityAttributes` blob).
+- `expiresAt` (Date), `registeredAt` (Date).
+
+### 4b. Workers KV / SQLite queue schema (server-side persistent storage)
+
+The SQLite schema below is the staging container's source of truth. In Workers KV each table becomes a namespace; queries degrade to namespace scans + in-memory filters (acceptable at the volumes we expect because the hot query is "due in the next 30s" and the queue is sharded per-device).
+
+```sql
+CREATE TABLE notification_plan (
+  id TEXT PRIMARY KEY,             -- deterministic: "{deviceID}.{kind}.{yyyy-MM-dd}"
+  device_id TEXT NOT NULL,
+  push_token TEXT NOT NULL,        -- snapshot at compute time
+  bundle_id TEXT NOT NULL,
+  fire_time INTEGER NOT NULL,      -- Unix epoch ms UTC
+  kind TEXT NOT NULL,              -- 'fasting_suhoor' | 'fasting_iftar' | 'fasting_daybefore' | 'prayer_fajr' | ...
+  payload_json TEXT NOT NULL,      -- full APNs aps payload as JSON
+  sent_at INTEGER,                 -- NULL until sent
+  last_error TEXT,
+  attempts INTEGER DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  computed_from TEXT NOT NULL      -- 'daily_cron' | 'settings_change' | 'manual_recompute'
+);
+CREATE INDEX idx_due ON notification_plan (fire_time) WHERE sent_at IS NULL;
+
+CREATE TABLE device_cache (
+  device_id TEXT PRIMARY KEY,
+  fetched_at INTEGER NOT NULL,
+  registration_json TEXT NOT NULL
+);
+
+CREATE TABLE error_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  occurred_at INTEGER NOT NULL,
+  device_id TEXT,
+  kind TEXT NOT NULL,
+  message TEXT NOT NULL,
+  context_json TEXT
+);
+CREATE INDEX idx_error_recent ON error_log (occurred_at DESC);
+
+CREATE TABLE service_state (
+  key TEXT PRIMARY KEY,
+  value_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+```
+
+### 4c. APNs payload format
+
+**Notification push (Suhoor, Iftar, etc.):**
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "🌙 Suhoor reminder",
+      "title-loc-key": "fasting.suhoor.title",
+      "body": "Suhoor ends in 30 min",
+      "loc-key": "fasting.suhoor.body",
+      "loc-args": ["30"]
+    },
+    "sound": "adhaan_fajr_1_notif.mp3",
+    "category": "FASTING_SUHOOR",
+    "thread-id": "fasting-mode",
+    "interruption-level": "time-sensitive",
+    "relevance-score": 1.0
+  },
+  "iqamah": {
+    "kind": "fasting_suhoor",
+    "fire_time_utc": 1764556800,
+    "scheduler_version": 1,
+    "for_local_date": "2026-03-15"
+  }
+}
+```
+
+APNs HTTP/2 headers per request:
+
+- `apns-topic: com.fablesoft.iqamah`
+- `apns-push-type: alert`
+- `apns-priority: 10` (immediate for prayer alerts)
+- `apns-expiration: fire_time + 60` (don't deliver stale pushes)
+- `apns-collapse-id: notification_plan.id` (idempotency — re-sends replace)
+- `authorization: bearer <JWT from .p8 key>`
+
+**Live Activity update push:**
+
+```json
+{
+  "aps": {
+    "timestamp": 1764556800,
+    "event": "update",
+    "content-state": {
+      "nextPrayerName": "Isha",
+      "nextPrayerTime": 1764568800,
+      "followingPrayerName": "Fajr",
+      "moonPhase": 0.42,
+      "hijriDateString": "23 Sha'ban 1447"
+    },
+    "stale-date": 1764568860,
+    "alert": { "title": "Prayer time", "body": "Isha at 8:45 PM" }
+  }
+}
+```
+
+LA push headers: `apns-topic: com.fablesoft.iqamah.push-type.liveactivity`, `apns-push-type: liveactivity`, `apns-priority: 5`, `apns-expiration: 0`.
+
+## 5. Per-flow detail
+
+### Scheduler
+
+- **Triggers:** daily cron at 04:00 UTC, 15-min CloudKit change-poll, on-demand `POST /api/recompute`.
+- For each device, compute the next **30 days** of plans, atomic SQLite transaction:
+
+```sql
+BEGIN;
+  DELETE FROM notification_plan WHERE device_id=? AND sent_at IS NULL AND fire_time > now();
+  INSERT new plans (deterministic IDs, INSERT OR REPLACE);
+COMMIT;
+```
+
+- Deterministic IDs (`{deviceID}.{kind}.{yyyy-MM-dd}`) make the operation idempotent: re-running produces the same queue state.
+
+### Sender (notifications)
+
+- 30-second tick. Query `WHERE sent_at IS NULL AND fire_time <= now() LIMIT 100`.
+- Send via APNs with `TaskGroup` concurrency 8.
+- Success → `UPDATE sent_at`. Failure → `UPDATE attempts++`, log error. 5 attempts max.
+- APNs `410 Gone` → mark device's token invalid, stop sending until the app re-registers.
+
+### LA Pusher
+
+- 60-second tick. Query active `LiveActivityRegistration` records.
+- For each, compute current `ContentState`. If it differs from the last push, send an LA update.
+- No retries — the next tick recomputes anyway.
+
+### Settings-change propagation (Mumbai → Delhi trace)
+
+1. App writes new `DeviceRegistration` to CloudKit.
+2. App opportunistically `POST`s to backend (~200ms on home Wi-Fi, fails silently on cellular — that's fine, see step 3).
+3. Backend Scheduler picks up the change via the opportunistic POST **or** the 15-minute CloudKit change-poll.
+4. Atomic transaction: DELETE old future plans + INSERT new ones.
+5. Sender's next 30-second tick fires the new times.
+6. LA Pusher's next 60-second tick updates the LA `ContentState`.
+
+## 6. Why deferred
+
+- Requires committing to **backend operations** — cost, SLA, monitoring, on-call. That's a meaningful identity shift from today's "client-only, no servers" posture.
+- ~$5–$10/mo at 100k MAU is the minimum credible cost; not free.
+- **Privacy / GDPR implications** when settings + location flow through developer infrastructure (vs staying device-local today). User-facing privacy policy and the Apple privacy manifest both need rework.
+- **ENH-0027** (cross-ecosystem expansion to Windows / Linux / Android) may change infrastructure decisions; worth waiting until that direction settles before sinking time into an Apple-only push backend.
+
+## 7. Promotion criteria
+
+Promote to EPIC + US when **all three** of these are true:
+
+1. Product decision made to commit to backend ops.
+2. Privacy review covers what user data leaves the device.
+3. Funding model (or developer's personal cost tolerance) agreed for hosting.
+
+## 8. References
+
+- PR #133 commit `405256a` — current foreground LA fix.
+- `iqamah/iOS/PrayerActivityManager.swift` — current Timer-based implementation.
+- `IqamahLiveActivity/PrayerActivityAttributes.swift` — `ContentState` shape (single source post-consolidation).
+- Apple ActivityKit push-token documentation.
+- Cloudflare Workers docs — Workers KV, Cron Triggers, scheduled handlers.
+- APNSwift, Hummingbird 2, SQLiteNIO — for the Swift staging container.


### PR DESCRIPTION
## Summary

Doc-only PR with four pieces — no code, no version bump, no build-number change.

1. **`docs/superpowers/specs/2026-05-24-enh-0026-push-driven-notifications-design.md`** — full design spec for push-driven notifications + background-reliable Live Activity. Captures the Cloudflare Workers (production) + local Mac Swift container (staging) architecture, CloudKit + SQLite/KV data model, APNs payloads, per-flow detail (Scheduler / Sender / LA Pusher), deferral reasoning, and promotion criteria.
2. **`docs/RELEASE_NOTES_v1.6.0.md`** — categorized v1.6.0 changelog (Fasting Mode EPIC-0017, BUG-0069 location-detect, PR #133 LA fix, macOS polish, dev-facing test/ID changes) plus a "Known limitations" section documenting suspended-app LA drift with workaround.
3. **`docs/ENHANCEMENTS.md`** — ENH-0026 entry rewritten to reference the new spec, replace speculative solution text with the parked design, and spell out the three-part promotion criteria.
4. **`README.md`** — adds a "Known Limitations" section between Testing and Contributing pointing at ENH-0026 and the v1.6.0 release notes.

## Files touched

```
 README.md                                                                                  |   6 +
 docs/ENHANCEMENTS.md                                                                       |  29 +--
 docs/RELEASE_NOTES_v1.6.0.md                                                               | 150 ++++++++++++++
 docs/superpowers/specs/2026-05-24-enh-0026-push-driven-notifications-design.md             | 228 +++++++++++++++++++++
```

All four files are `.md`. `git diff --stat origin/main..HEAD` confirms no code, no asset, no project-file changes.

## Test plan

- [ ] Skim the design spec — section ordering, code blocks render, internal cross-links resolve
- [ ] Skim `RELEASE_NOTES_v1.6.0.md` — categorized list reads cleanly, "Known limitations" link to the spec works on GitHub render
- [ ] Confirm `docs/ENHANCEMENTS.md` ENH-0026 entry replaces the old one cleanly (no leftover paragraphs)
- [ ] Confirm `README.md` "Known Limitations" entry sits in the right spot and the two relative links resolve
- [ ] `git diff --stat origin/main..HEAD` shows only `*.md` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)