### PR TITLE
fix(BUG-0070): anchor AdhaanBanner panel under menu-bar status item

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -10,7 +10,29 @@ All bugs and defects tracked here with BUG-XXXX identifiers and status.
 **Medium:** 0
 **Low:** 0
 
-> **All bugs BUG-0001 through BUG-0069 resolved as of 2026-05-24.** v1.5 (15) accepted by App Store; v1.6.0 in development.
+> **All bugs BUG-0001 through BUG-0070 resolved as of 2026-05-24.** v1.5 (15) accepted by App Store; v1.6.0 in development.
+
+---
+
+## Session — 2026-05-24 (AdhaanBanner anchor — v1.6.0 dev)
+
+### Resolved
+
+**BUG-0070 (macOS): AdhaanBannerController panel appears center-screen instead of dropping from menu-bar status item**
+
+**Severity:** 🟡 P2 — Medium (visual/UX regression; functionality unaffected)
+**Reported:** 2026-05-24 — internal QA on v1.6.0 dev build
+**Status:** ✅ Fixed — same PR
+**Affected platforms:** macOS
+**Affected versions:** v1.5 (15) and earlier dev builds with the adhaan banner
+
+**Description:** When an adhaan plays and the floating notification panel appears, it animates down from the top of the screen but is horizontally centered on the entire display rather than under the Iqamah menu-bar status item. On wide displays this makes the panel feel disconnected from its origin — users reported it as "appearing in the middle of the screen" rather than "dropping from the menu bar."
+
+**Root cause:** `AdhaanBannerController.positionPanel(_:size:animated:)` computed `centreX = screenFrame.midX - size.width / 2`, completely ignoring the position of the `NSStatusItem` button window.
+
+**Fix:** Thread the status item's screen-coordinate frame (`statusItem.button?.window?.frame`) through a new optional `statusItemFrame:` parameter on `AdhaanBannerController.show(...)`. `positionPanel` now centers the panel under the anchor's midX, clamped to `[screenFrame.minX + 12, screenFrame.maxX - size.width - 12]` so it never spills off a narrow display. When no anchor is provided (status item not yet created, screen disconnected), falls back to the previous screen-center behaviour — guaranteed never to regress.
+
+**Verification:** Trigger an adhaan when the status item is near the far-right of the menu bar; the banner now drops from directly below it rather than from the centre.
 
 ---
 

--- a/docs/ID_REGISTRY.md
+++ b/docs/ID_REGISTRY.md
@@ -13,7 +13,7 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 | TASK         | TASK-0001             | None              |
 | AC           | AC-0383               | AC-0382           |
 | TC           | TC-0074               | TC-0073           |
-| BUG          | BUG-0070              | BUG-0069          |
+| BUG          | BUG-0071              | BUG-0070          |
 | ENH          | ENH-0028               | ENH-0027           |
 
 ---
@@ -28,4 +28,4 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 
 ---
 
-**Last Updated:** 2026-05-24 (ENH-0027 logged — Cross-Ecosystem Expansion to Windows/Linux/Android via Rust+UniFFI shared core, golden test-vector contract, and per-platform Claude Code subagents.)
+**Last Updated:** 2026-05-24 (BUG-0070 logged and fixed — AdhaanBanner panel now anchors under menu-bar status item instead of screen-center.)

--- a/iqamah/AppDelegate.swift
+++ b/iqamah/AppDelegate.swift
@@ -295,7 +295,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                         prayerTime: prayer.time,
                         adhaan: adhaan,
                         allPrayers: adjustedPrayers,
-                        timezone: timezone // city's timezone, not device timezone
+                        timezone: timezone, // city's timezone, not device timezone
+                        statusItemFrame: self.statusItem?.button?.window?.frame
                     )
                 }
             }

--- a/iqamah/Services/AdhaanBannerController.swift
+++ b/iqamah/Services/AdhaanBannerController.swift
@@ -26,7 +26,8 @@ final class AdhaanBannerController {
         prayerTime: Date,
         adhaan: Adhaan,
         allPrayers: [(name: String, time: Date)],
-        timezone: TimeZone
+        timezone: TimeZone,
+        statusItemFrame: NSRect? = nil
     ) {
         // Dismiss any existing banner first
         hide(animated: false)
@@ -68,7 +69,7 @@ final class AdhaanBannerController {
         newPanel.contentView = hosting
         newPanel.collectionBehavior = [.canJoinAllSpaces, .stationary]
 
-        positionPanel(newPanel, size: bannerSize, animated: true)
+        positionPanel(newPanel, size: bannerSize, anchor: statusItemFrame, animated: true)
         panel = newPanel
 
         // Auto-transition to CLOSE when playback ends naturally
@@ -119,19 +120,33 @@ final class AdhaanBannerController {
 
     // MARK: - Private
 
-    private func positionPanel(_ panel: NSPanel, size: CGSize, animated: Bool) {
+    private func positionPanel(_ panel: NSPanel, size: CGSize, anchor: NSRect?, animated: Bool) {
         guard let screen = NSScreen.main else { return }
 
         let screenFrame = screen.frame
         let menuBarHeight: CGFloat = screenFrame.height - screen.visibleFrame.height
             - screen.visibleFrame.origin.y
 
-        let centreX = screenFrame.midX - size.width / 2
+        // Horizontal: anchor under the menu-bar status item when available,
+        // clamped to screen edges so the panel never spills off-screen on narrow displays.
+        // Falls back to screen-center when no anchor is provided (status item not yet
+        // ready or screen disconnected) — preserves previous behaviour in edge cases.
+        let edgePad: CGFloat = 12
+        let anchorX: CGFloat
+        if let anchor {
+            let ideal = anchor.midX - size.width / 2
+            let minX = screenFrame.minX + edgePad
+            let maxX = screenFrame.maxX - size.width - edgePad
+            anchorX = min(max(ideal, minX), maxX)
+        } else {
+            anchorX = screenFrame.midX - size.width / 2
+        }
+
         let finalY = screenFrame.maxY - menuBarHeight - size.height - 12
         let startY = screenFrame.maxY + 10 // above screen, hidden
 
         panel.setFrame(
-            NSRect(x: centreX, y: startY, width: size.width, height: size.height),
+            NSRect(x: anchorX, y: startY, width: size.width, height: size.height),
             display: false
         )
         panel.orderFront(nil)
@@ -141,13 +156,13 @@ final class AdhaanBannerController {
                 ctx.duration = 0.45
                 ctx.timingFunction = CAMediaTimingFunction(controlPoints: 0.34, 1.56, 0.64, 1)
                 panel.animator().setFrame(
-                    NSRect(x: centreX, y: finalY, width: size.width, height: size.height),
+                    NSRect(x: anchorX, y: finalY, width: size.width, height: size.height),
                     display: true
                 )
             }
         } else {
             panel.setFrame(
-                NSRect(x: centreX, y: finalY, width: size.width, height: size.height),
+                NSRect(x: anchorX, y: finalY, width: size.width, height: size.height),
                 display: true
             )
         }


### PR DESCRIPTION
## Summary

Fixes **BUG-0070**: the macOS adhaan notification banner was horizontally centered on the entire screen instead of dropping down from the Iqamah menu-bar status item. On wide displays this made the panel feel disconnected from its origin — users reported it as "appearing in the middle of the screen" rather than "from the menu bar."

## The bug

`AdhaanBannerController.positionPanel(_:size:animated:)` computed `centreX = screenFrame.midX - size.width / 2`, completely ignoring where the `NSStatusItem` button window actually lives. Vertical positioning was already correct (just below the menu bar) — only the horizontal anchor was broken.

## The fix

- Added an optional `statusItemFrame: NSRect?` parameter to `AdhaanBannerController.show(...)`.
- `AppDelegate` (the only caller) passes `statusItem?.button?.window?.frame` — already in screen coordinates.
- `positionPanel` now centres the panel under `anchor.midX`, clamped to `[screenFrame.minX + 12, screenFrame.maxX - size.width - 12]` so the panel never spills off-screen on a narrow display.
- When no anchor is provided (status item not yet created, screen disconnected during call), falls back to the previous screen-center behaviour — guaranteed never to regress.

No changes to vertical positioning, animation curve, or timing.

## Test plan

- [x] `swift build` + `swift test` (`Packages/IqamahCore`) — 258 tests pass.
- [x] `xcodebuild -scheme iqamah -configuration Debug` — BUILD SUCCEEDED.
- [x] `swiftformat --lint --strict` + `swiftlint --strict` clean on both changed files.
- [ ] Manual: move the menu bar so the Iqamah status item sits at the far-right of the screen. Trigger an adhaan (or wait for one). Banner should drop from directly under the status item, not from the centre.
- [ ] Manual: on a wide ultrawide display, confirm the panel never spills off the right edge.
- [ ] Manual: disconnect external display mid-adhaan (edge case) — banner should still appear (falls back to screen-center), not crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)