### PR TITLE
docs(bugs): zero out stale 'Active Bugs' summary header

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -4,13 +4,13 @@ All bugs and defects tracked here with BUG-XXXX identifiers and status.
 
 ---
 
-**Total Active Bugs:** 2
-**Critical:** 1
-**High:** 1
+**Total Active Bugs:** 0
+**Critical:** 0
+**High:** 0
 **Medium:** 0
 **Low:** 0
 
-> **All bugs BUG-0001 through BUG-0070 resolved as of 2026-05-24.** v1.5 (15) accepted by App Store; v1.6.0 in development.
+> **All bugs BUG-0001 through BUG-0070 resolved as of 2026-05-24.** v1.5 (15) accepted by App Store; v1.6.0 in development. No open defects blocking v1.6.0 (15) submission.
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/BUGS.md`'s top-of-file 'Total Active Bugs' summary table said `2` (1 Critical, 1 High) but the explanatory line directly below it said 'All bugs BUG-0001 through BUG-0070 resolved as of 2026-05-24'. Two contradictory sources of truth in the same file.

PR #141 (BUG-0068 + BUG-0069 close-out) and PR #146 (BUG-0070 fix) updated the per-session blocks but didn't touch the hand-maintained summary table. This PR syncs the table.

## Changes

```diff
-**Total Active Bugs:** 2
-**Critical:** 1
-**High:** 1
+**Total Active Bugs:** 0
+**Critical:** 0
+**High:** 0
```

Plus a clarifying sentence appended to the existing summary line: 'No open defects blocking v1.6.0 (15) submission.'

Pure doc-only PR. Zero code touched. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)