### PR TITLE
chore(privacy): declare Required Reason API usage for App Store submission

### DIFF
--- a/IqamahLiveActivity/PrivacyInfo.xcprivacy
+++ b/IqamahLiveActivity/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: Accessed to read and write settings set and updated by the app itself -->
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/IqamahWatch/PrivacyInfo.xcprivacy
+++ b/IqamahWatch/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: Accessed to read and write settings set and updated by the app itself -->
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/IqamahWatchWidget/PrivacyInfo.xcprivacy
+++ b/IqamahWatchWidget/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: Accessed to read and write settings set and updated by the app itself -->
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/IqamahWidget/PrivacyInfo.xcprivacy
+++ b/IqamahWidget/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: Accessed to read and write settings set and updated by the app itself -->
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Packages/IqamahCore/Sources/IqamahCore/Resources/PrivacyInfo.xcprivacy
+++ b/Packages/IqamahCore/Sources/IqamahCore/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: Accessed to read and write settings set and updated by the app itself -->
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/iqamah.xcodeproj/project.pbxproj
+++ b/iqamah.xcodeproj/project.pbxproj
@@ -58,6 +58,12 @@
 		MB000000000000000000BB02 /* MenuBarPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MB000000000000000000BB01 /* MenuBarPopoverView.swift */; };
 		MW00000000000000000050 /* IqamahWidgetMac.appex in Embed Mac Widget Extension */ = {isa = PBXBuildFile; fileRef = MW00000000000000000002 /* IqamahWidgetMac.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		PI000000000000000000BB01 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = PI000000000000000000AA01 /* PrivacyInfo.xcprivacy */; };
+		PI0000000000000000000B02 /* PrivacyInfo.xcprivacy in Resources (iOS) */ = {isa = PBXBuildFile; fileRef = PI0000000000000000000A02 /* PrivacyInfo.xcprivacy (iOS) */; };
+		PI0000000000000000000B03 /* PrivacyInfo.xcprivacy in Resources (Watch) */ = {isa = PBXBuildFile; fileRef = PI0000000000000000000A03 /* PrivacyInfo.xcprivacy (Watch) */; };
+		PI0000000000000000000B04 /* PrivacyInfo.xcprivacy in Resources (Widget) */ = {isa = PBXBuildFile; fileRef = PI0000000000000000000A04 /* PrivacyInfo.xcprivacy (Widget) */; };
+		PI0000000000000000000B05 /* PrivacyInfo.xcprivacy in Resources (Widget Mac) */ = {isa = PBXBuildFile; fileRef = PI0000000000000000000A04 /* PrivacyInfo.xcprivacy (Widget) */; };
+		PI0000000000000000000B06 /* PrivacyInfo.xcprivacy in Resources (LiveActivity) */ = {isa = PBXBuildFile; fileRef = PI0000000000000000000A06 /* PrivacyInfo.xcprivacy (LiveActivity) */; };
+		PI0000000000000000000B07 /* PrivacyInfo.xcprivacy in Resources (WatchWidget) */ = {isa = PBXBuildFile; fileRef = PI0000000000000000000A07 /* PrivacyInfo.xcprivacy (WatchWidget) */; };
 		SH00000000000000000001A /* HilalShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = SH00000000000000000000A /* HilalShareSheet.swift */; };
 		WA000000000000000000011 /* WatchLocationSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = WA000000000000000000011R /* WatchLocationSetupView.swift */; };
 		WA000000000000000000012 /* PrayerTimesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = WA000000000000000000012R /* PrayerTimesTab.swift */; };
@@ -309,6 +315,11 @@
 		MW00000000000000000003 /* InfoMac.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = InfoMac.plist; sourceTree = "<group>"; };
 		MW00000000000000000004 /* IqamahWidgetMac.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IqamahWidgetMac.entitlements; sourceTree = "<group>"; };
 		PI000000000000000000AA01 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		PI0000000000000000000A02 /* PrivacyInfo.xcprivacy (iOS) */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		PI0000000000000000000A03 /* PrivacyInfo.xcprivacy (Watch) */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		PI0000000000000000000A04 /* PrivacyInfo.xcprivacy (Widget) */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		PI0000000000000000000A06 /* PrivacyInfo.xcprivacy (LiveActivity) */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		PI0000000000000000000A07 /* PrivacyInfo.xcprivacy (WatchWidget) */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		SH00000000000000000000A /* HilalShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HilalShareSheet.swift; sourceTree = "<group>"; };
 		TT000000000000000000AA01 /* tone_glass.aiff */ = {isa = PBXFileReference; lastKnownFileType = audio.aiff; path = tone_glass.aiff; sourceTree = "<group>"; };
 		TT000000000000000000AA02 /* tone_ping.aiff */ = {isa = PBXFileReference; lastKnownFileType = audio.aiff; path = tone_ping.aiff; sourceTree = "<group>"; };
@@ -634,6 +645,7 @@
 			children = (
 				LA000000000000000000010R /* PrayerActivityAttributes.swift */,
 				LA000000000000000000011R /* PrayerLiveActivityView.swift */,
+				PI0000000000000000000A06 /* PrivacyInfo.xcprivacy (LiveActivity) */,
 			);
 			path = IqamahLiveActivity;
 			sourceTree = "<group>";
@@ -649,6 +661,7 @@
 				WA000000000000000000014R /* SettingsTab.swift */,
 				WA000000000000000000015R /* WatchNotificationScheduler.swift */,
 				WA000000000000000000016R /* WatchSessionManager.swift */,
+				PI0000000000000000000A03 /* PrivacyInfo.xcprivacy (Watch) */,
 			);
 			path = IqamahWatch;
 			sourceTree = "<group>";
@@ -665,6 +678,7 @@
 				MW00000000000000000004 /* IqamahWidgetMac.entitlements */,
 				WG000000000000000000012 /* Info.plist */,
 				WG000000000000000000013 /* IqamahWidget.entitlements */,
+				PI0000000000000000000A04 /* PrivacyInfo.xcprivacy (Widget) */,
 			);
 			path = IqamahWidget;
 			sourceTree = "<group>";
@@ -684,6 +698,7 @@
 				WW000000000000000000040R /* PrayerEntry.swift */,
 				WW000000000000000000041R /* PrayerTimelineProvider.swift */,
 				WW000000000000000000032R /* IqamahWatchWidget.swift */,
+				PI0000000000000000000A07 /* PrivacyInfo.xcprivacy (WatchWidget) */,
 			);
 			path = IqamahWatchWidget;
 			sourceTree = "<group>";
@@ -701,6 +716,7 @@
 				HC000000000000000000003 /* PrayerRowMobileView.swift */,
 				iOS0000000000000000000013 /* Info.plist */,
 				iOS0000000000000000000014 /* iqamah-iOS.entitlements */,
+				PI0000000000000000000A02 /* PrivacyInfo.xcprivacy (iOS) */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -1009,6 +1025,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				PI0000000000000000000B05 /* PrivacyInfo.xcprivacy in Resources (Widget Mac) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1054,6 +1071,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				PI0000000000000000000B06 /* PrivacyInfo.xcprivacy in Resources (LiveActivity) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1062,6 +1080,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				WA000000000000000000060 /* Assets.xcassets in Resources */,
+				PI0000000000000000000B03 /* PrivacyInfo.xcprivacy in Resources (Watch) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1069,6 +1088,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				PI0000000000000000000B04 /* PrivacyInfo.xcprivacy in Resources (Widget) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1076,6 +1096,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				PI0000000000000000000B07 /* PrivacyInfo.xcprivacy in Resources (WatchWidget) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1085,6 +1106,7 @@
 			files = (
 				iOS000000000000000000000F /* Assets.xcassets in Resources */,
 				iOS000000000000000000002A /* splash.jpg in Resources (iOS) */,
+				PI0000000000000000000B02 /* PrivacyInfo.xcprivacy in Resources (iOS) */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iqamah/iOS/PrivacyInfo.xcprivacy
+++ b/iqamah/iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: Accessed to read and write settings set and updated by the app itself -->
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

App Store submission readiness audit found that only the macOS `iqamah` target shipped a `PrivacyInfo.xcprivacy` manifest. Every other shipped binary (iqamah-iOS, IqamahWatch, IqamahWidget, IqamahWidgetMac, IqamahLiveActivity, IqamahWatchWidget) was missing one, which causes App Store Connect to auto-reject iOS 17+ / macOS 14+ / watchOS 10+ submissions for any target that uses a Required Reason API.

Every app and extension target links `IqamahCore`, whose `SettingsManager` reads/writes `UserDefaults` — that's `NSPrivacyAccessedAPICategoryUserDefaults`, reason `CA92.1` ("Access info from same app, per documentation").

## Audit findings (before this PR)

| Target | Manifest? | UserDefaults declared? | Other categories needed | Pbxproj registered |
|---|---|---|---|---|
| iqamah (macOS) | yes | yes | none | yes |
| iqamah-iOS | NO | n/a | none | n/a |
| IqamahWatch | NO | n/a | none | n/a |
| IqamahWidget (iOS) | NO | n/a | none | n/a |
| IqamahWidgetMac | NO | n/a | none | n/a |
| IqamahLiveActivity | NO | n/a | none | n/a |
| IqamahWatchWidget | NO | n/a | none | n/a |

After this PR all rows are `yes / yes / none / yes`. No other Required Reason API categories are needed — source-tree audit found no use of file timestamps, system boot time, disk space, or active keyboard APIs. CoreLocation and UserNotifications are permission-based (covered by Info.plist), not Required Reason APIs.

## Changes

- Adds `PrivacyInfo.xcprivacy` to each missing target's folder (`iqamah/iOS/`, `IqamahWatch/`, `IqamahWidget/`, `IqamahLiveActivity/`, `IqamahWatchWidget/`). The Widget folder file ref is shared by both `IqamahWidget` (iOS) and `IqamahWidgetMac` since they compile from the same folder.
- Adds one to `Packages/IqamahCore/Sources/IqamahCore/Resources/` so the package's own resource bundle declares the API too.
- Wires each new file into the appropriate target's "Copy Bundle Resources" build phase in `iqamah.xcodeproj/project.pbxproj`.
- All manifests use identical content: declares `NSPrivacyAccessedAPICategoryUserDefaults` with `CA92.1`, `NSPrivacyTracking = false`, empty tracking domains, empty collected data types.

No code changes, no version bump.

## Test plan

- [x] `plutil -lint` clean on all seven `.xcprivacy` files
- [x] `xcodebuild` succeeds for `iqamah` (macOS), `iqamah-iOS`, and `IqamahWatch` schemes
- [x] Inspected built bundles — every `.app` and `.appex` (including embedded watchOS app, widgets, and live activity) now contains a `PrivacyInfo.xcprivacy` at its root
- [ ] Archive build and upload to App Store Connect succeeds without Required Reason API warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)