### PR TITLE
docs: ENH-0028/0029 (test infra gaps) + archive 2026-05-03 plan

### DIFF
--- a/docs/ENHANCEMENTS.md
+++ b/docs/ENHANCEMENTS.md
@@ -844,3 +844,59 @@ IqamahCore/
 All four app targets (macOS, iOS, watchOS, visionOS) import `IqamahCore`. Platform-specific code (AppDelegate, status bar, notification scheduling, complications) lives in each target separately. This prevents the codebase from becoming a sea of `#if os(macOS)` conditionals and makes the boundaries explicit.
 
 **Estimated total effort across all platforms:** 12–18 weeks of focused development, assuming one developer.
+
+---
+
+## Testing & Quality Infrastructure
+
+### ENH-0028 — Add watchOS test target to IqamahWatch scheme
+**Source:** Multi-platform test suite run, 2026-05-24 (v1.6.0 pre-submission audit)
+**Priority:** Medium — coverage gap rather than user-visible defect
+
+**Problem:** The `IqamahWatch` xcodebuild scheme has no XCTest bundle attached. Running `xcodebuild test -scheme IqamahWatch` reports `Executed 0 tests`. All watch-app confidence today comes indirectly from (a) IqamahCore unit tests (which the watch target links) and (b) the fact that the watch app compiles cleanly on the simulator. Watch-specific code paths — Watch Connectivity messages, complications, `WKExtendedRuntimeSession`, watchOS-only UI like `SettingsTab` and `WatchLocationSetupView` — have zero automated coverage.
+
+**Proposed solution:** Add a new `IqamahWatchTests` target to `iqamah.xcodeproj` and attach it to the `IqamahWatch` scheme's Test action. Initial test set should cover:
+- The `SettingsTab` Fasting Mode section state transitions
+- `WatchLocationSetupView` GPS timeout simulation
+- `WatchNotificationScheduler` reschedule debouncing (parallel to the iOS scheduler test we'd add in ENH-0029)
+- `PrayerTimesTab` row relabel via `FastingLabelFormatter` (matching the macOS snapshot test pattern)
+
+**Why backlog (not Epic yet):**
+- Adding a new xcodebuild target requires careful pbxproj edits and CI workflow updates (the `Snapshot Tests` and `Test & Coverage` CI jobs would need to invoke the watch scheme too)
+- Watch simulator test runs are slow (~50s per scheme just to build); CI cost adds up
+- No watch-specific defect is currently driving the need — gap was discovered via audit, not user report
+
+**Promotion criteria:** Promote to EPIC + US when (a) a watchOS-only bug ships that would have been caught by such tests, OR (b) a planned watchOS feature (e.g., complications redesign) reaches design phase and we want test coverage before shipping.
+
+**References:**
+- `IqamahWatch/` (target source)
+- `iqamah.xcodeproj/project.pbxproj` (target wiring)
+- `.github/workflows/ci.yml` (CI test runner — `Snapshot Tests` and `Test & Coverage` jobs would extend to invoke watch tests)
+- 2026-05-24 multi-platform test suite report (the discovery)
+
+---
+
+### ENH-0029 — Add iOS-specific unit test target to iqamah-iOS scheme
+**Source:** Multi-platform test suite run, 2026-05-24 (v1.6.0 pre-submission audit)
+**Priority:** Medium — coverage gap rather than user-visible defect
+
+**Problem:** The `iqamah-iOS` xcodebuild scheme runs only the `IqamahiOSUITests` target (8 UI tests, ~9 min wall time including simulator boot). There is no `iqamah-iOSTests` unit test bundle. iOS-specific runtime code — UIKit lifecycle in `iqamahApp_iOS`, `BGAppRefreshTask` registration, `NotificationScheduler` extension methods, iOS-only views like `PrayerHeroCard` and `PrayerRowMobileView` — has no fast unit coverage. UI tests catch end-to-end regressions but are slow and brittle for logic-level assertions.
+
+**Proposed solution:** Add an `iqamah-iOSTests` target and attach it to the iOS scheme's Test action. Initial test set should cover:
+- `PrayerHeroCard` state machine (active fasting / prohibition / inactive)
+- iOS `NotificationScheduler.scheduleFastingReminders(...)` debounce + cancellation (parallel to watchOS scheduler tests in ENH-0028)
+- `PrayerActivityManager` Live Activity start/update/end lifecycle (mocking `ActivityKit` where needed)
+- `iOSRootView` onboarding flow state transitions
+
+**Why backlog (not Epic yet):**
+- Same as ENH-0028: pbxproj wiring + CI workflow updates
+- iOS-specific code today is intentionally thin (most logic lives in IqamahCore); the gap is real but not large
+- No iOS-only defect is currently driving the need
+
+**Promotion criteria:** Promote to EPIC + US when (a) an iOS-only bug ships that would have been caught by such tests, OR (b) iOS-only code grows substantially (e.g., a new iOS-only feature in v1.7+).
+
+**References:**
+- `iqamah/iOS/` (target source)
+- `iqamah.xcodeproj/project.pbxproj` (target wiring)
+- `.github/workflows/ci.yml` (CI test runner)
+- 2026-05-24 multi-platform test suite report (the discovery)

--- a/docs/ID_REGISTRY.md
+++ b/docs/ID_REGISTRY.md
@@ -14,7 +14,7 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 | AC           | AC-0383               | AC-0382           |
 | TC           | TC-0074               | TC-0073           |
 | BUG          | BUG-0071              | BUG-0070          |
-| ENH          | ENH-0028               | ENH-0027           |
+| ENH          | ENH-0030               | ENH-0029           |
 
 ---
 
@@ -28,4 +28,4 @@ Single source of truth for the next available ID in each artefact sequence. Upda
 
 ---
 
-**Last Updated:** 2026-05-24 (BUG-0070 logged and fixed — AdhaanBanner panel now anchors under menu-bar status item instead of screen-center.)
+**Last Updated:** 2026-05-24 (ENH-0028, ENH-0029 logged — watchOS and iOS test target gaps surfaced by v1.6.0 pre-submission test suite audit. Plus archived 2026-05-03 close-issues-4-5-6 plan doc.)

--- a/docs/superpowers/plans/2026-05-03-close-issues-4-5-6.md
+++ b/docs/superpowers/plans/2026-05-03-close-issues-4-5-6.md
@@ -1,0 +1,701 @@
+# Close Issues #4, #5, #6 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close GitHub issues #5 (cities.json CI path filter), #6 (bundle size budget in CI), and #4 (prayer accuracy regression tests) on the ksyed0/iqamah repo.
+
+**Architecture:** Three sequential feature branches off `develop`, each merged via squash PR. Issues #5 and #6 are CI-only changes (no Swift); issue #4 adds a Swift test file and a `project.pbxproj` entry.
+
+**Tech Stack:** GitHub Actions (YAML), Python 3, Swift Testing framework, Xcode 16.2, `xcodebuild`, `du`
+
+**Worktree root:** `/Users/Kamal_Syed/Projects/iqamah/iqamah/.claude/worktrees/wonderful-leavitt-94b47a`
+(All file paths below are relative to this root, which mirrors the repo root.)
+
+---
+
+## Status of existing work
+
+- `scripts/validate_cities.py` — **already complete**. Validates name, countryCode, lat/lon, IANA tz.
+- `.github/workflows/ci.yml` `validate_cities` job — **exists but lacks `paths:` filter**.
+- `.github/workflows/ci.yml` `file-size` job — **exists but checks repo files > 10 MB, NOT the .app bundle**.
+- `Tests/PrayerAccuracyRegressionTests.swift` — **does not exist**.
+
+---
+
+## Task 1: Issue #5 — cities.json path-filtered CI workflow
+
+**Branch:** `fix/issue-5-cities-ci-path-filter`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` — add `paths:` filter to `validate_cities` job's effective trigger by creating a new workflow file
+- Create: `.github/workflows/validate-cities.yml` — dedicated workflow with `paths:` filter (alternative: inline condition in ci.yml)
+
+**Chosen approach:** Keep the existing `validate_cities` job in `ci.yml` (runs always — satisfies "must run on any PR touching cities.json"). Add `paths-filter` via a new lightweight dedicated workflow so the job also runs path-conditionally on changed `cities.json`. Since the existing job already satisfies the requirement, the minimal change is to verify the CI job is correct and close the issue. However, to explicitly demonstrate the path filter intent, we will add `paths:` to the `validate_cities` job in `ci.yml` using a conditional approach.
+
+**Simpler implementation:** Add a `paths` push/PR trigger at the workflow level for a new dedicated workflow file `validate-cities.yml`, and remove the `validate_cities` job from `ci.yml` to avoid redundancy. This way CI is clean.
+
+- [ ] **Step 1: Branch off develop**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+git checkout develop
+git pull origin develop
+git checkout -b fix/issue-5-cities-ci-path-filter
+```
+
+- [ ] **Step 2: Create `.github/workflows/validate-cities.yml`**
+
+Create the file at `.github/workflows/validate-cities.yml`:
+
+```yaml
+name: Validate cities.json
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'iqamah/Resources/cities.json'
+      - 'scripts/validate_cities.py'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'iqamah/Resources/cities.json'
+      - 'scripts/validate_cities.py'
+
+jobs:
+  validate_cities:
+    name: Validate cities.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run schema validation
+        run: python3 scripts/validate_cities.py
+```
+
+- [ ] **Step 3: Remove the `validate_cities` job from `ci.yml`**
+
+In `.github/workflows/ci.yml`, delete the entire `validate_cities` block (lines starting with `validate_cities:` through the `run: python3 scripts/validate_cities.py` line) so it's no longer duplicated.
+
+The block to remove is:
+```yaml
+  # ──────────────────────────────────────────────────────────────────────────
+  # 0. DATA VALIDATION — cities.json schema check
+  # ──────────────────────────────────────────────────────────────────────────
+  validate_cities:
+    name: Validate cities.json
+    runs-on: ubuntu-latest   # no Xcode needed — pure Python
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run schema validation
+        run: python3 scripts/validate_cities.py
+```
+
+- [ ] **Step 4: Verify script runs locally**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+python3 scripts/validate_cities.py
+```
+
+Expected output ends with: `✅  cities.json valid — <N> cities, <M> countries`
+Expected exit code: 0
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+git add .github/workflows/validate-cities.yml .github/workflows/ci.yml
+git commit -m "ci: path-filter cities.json validation to dedicated workflow
+
+Moves the validate_cities CI job into its own workflow file so it
+only runs on PRs/pushes that touch cities.json or the validator script,
+instead of running on every push to any file.
+
+Closes #5"
+```
+
+- [ ] **Step 6: Push and open PR**
+
+```bash
+git push origin fix/issue-5-cities-ci-path-filter
+gh pr create \
+  --title "ci: path-filter cities.json validation to dedicated workflow" \
+  --body "$(cat <<'EOF'
+## Summary
+- Moves `validate_cities` job from `ci.yml` into a new `validate-cities.yml` workflow
+- New workflow runs only on PRs/pushes that touch `iqamah/Resources/cities.json` or `scripts/validate_cities.py`
+- Reduces unnecessary CI minutes on PRs that don't touch the cities data
+
+## Test plan
+- [ ] Verify `validate-cities.yml` appears in GitHub Actions on merge
+- [ ] Verify a PR that touches `cities.json` triggers the new workflow
+- [ ] Verify a PR that doesn't touch `cities.json` does NOT trigger it
+
+Closes #5
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" \
+  --base develop \
+  --repo ksyed0/iqamah
+```
+
+- [ ] **Step 7: Wait for CI green, merge, close issue**
+
+```bash
+# Watch CI
+gh pr checks --watch --repo ksyed0/iqamah
+
+# Merge when green
+gh pr merge --squash --repo ksyed0/iqamah
+
+# Close issue
+gh issue close 5 --repo ksyed0/iqamah --comment "Fixed in this PR: validate-cities.yml now runs on any PR touching cities.json via paths filter."
+```
+
+---
+
+## Task 2: Issue #6 — bundle size budget check in CI
+
+**Branch:** `fix/issue-6-bundle-size-ci`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` — replace existing `file-size` job with a proper `.app` bundle size check
+
+**Note:** The `build` job already builds Release. We need a new job that builds Release, locates the `.app`, runs `du -sm`, and fails if > 50 MB.
+
+- [ ] **Step 1: Branch off develop**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+git checkout develop
+git pull origin develop
+git checkout -b fix/issue-6-bundle-size-ci
+```
+
+- [ ] **Step 2: Replace the `file-size` job in `ci.yml`**
+
+Locate the existing `file-size` job in `.github/workflows/ci.yml`:
+
+```yaml
+  # ──────────────────────────────────────────────────────────────────────────
+  # 6. FILE SIZE GUARD — prevent accidentally committing large binaries
+  # ──────────────────────────────────────────────────────────────────────────
+  file-size:
+    name: File Size Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for files > 10 MB
+        run: |
+          LARGE=$(find . -not -path './.git/*' -size +10M)
+          if [ -n "$LARGE" ]; then
+            echo "::error::Files exceeding 10 MB found:"
+            echo "$LARGE"
+            exit 1
+          fi
+          echo "All files within size limit."
+```
+
+Replace it with:
+
+```yaml
+  # ──────────────────────────────────────────────────────────────────────────
+  # 6. FILE SIZE GUARD — .app bundle must not exceed 50 MB (Release build)
+  # ──────────────────────────────────────────────────────────────────────────
+  file-size:
+    name: File Size Guard
+    runs-on: macos-15
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Create adhaan stub files for CI build
+        run: |
+          for name in adhaan_1 adhaan_2 adhaan_3 adhaan_4 adhaan_5 \
+                      adhaan_fajr_1 adhaan_fajr_2 adhaan_fajr_3; do
+            touch "iqamah/Resources/${name}.mp3"
+          done
+
+      - name: Build Release
+        run: |
+          xcodebuild \
+            -project ${{ env.PROJECT }} \
+            -scheme ${{ env.SCHEME }} \
+            -configuration Release \
+            -destination 'platform=macOS' \
+            -derivedDataPath DerivedData \
+            build \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty --color && exit ${PIPESTATUS[0]}
+
+      - name: Check .app bundle size (≤ 50 MB)
+        run: |
+          APP=$(find DerivedData -name "*.app" -maxdepth 6 | head -1)
+          if [ -z "$APP" ]; then
+            echo "::error::Could not find .app bundle in DerivedData"
+            exit 1
+          fi
+          SIZE_MB=$(du -sm "$APP" | cut -f1)
+          echo "Bundle size: ${SIZE_MB} MB  (path: $APP)"
+          if [ "$SIZE_MB" -gt 50 ]; then
+            echo "::error::Bundle size ${SIZE_MB} MB exceeds the 50 MB budget."
+            exit 1
+          fi
+          echo "::notice::Bundle size ${SIZE_MB} MB is within the 50 MB budget."
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+git add .github/workflows/ci.yml
+git commit -m "ci: replace file-size job with Release .app bundle budget check
+
+Previous job only scanned for repo files > 10 MB (committed binaries).
+New job builds the Release .app and fails CI if the bundle exceeds 50 MB,
+giving an accurate signal on shipped artifact size.
+
+Closes #6"
+```
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push origin fix/issue-6-bundle-size-ci
+gh pr create \
+  --title "ci: replace file-size job with Release .app bundle budget check" \
+  --body "$(cat <<'EOF'
+## Summary
+- Replaces the previous `file-size` job (repo file scan) with a Release `xcodebuild` + `du -sm` check on the `.app` bundle
+- CI fails if the bundle exceeds 50 MB
+- Prints actual bundle size in MB on success so it's visible in CI logs
+
+## Test plan
+- [ ] CI passes on this PR (bundle currently well under 50 MB)
+- [ ] Bundle size is printed in the step output
+
+Closes #6
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" \
+  --base develop \
+  --repo ksyed0/iqamah
+```
+
+- [ ] **Step 5: Wait for CI green, merge, close issue**
+
+```bash
+gh pr checks --watch --repo ksyed0/iqamah
+gh pr merge --squash --repo ksyed0/iqamah
+gh issue close 6 --repo ksyed0/iqamah --comment "Fixed: CI now builds Release and checks .app bundle size with du -sm, failing if > 50 MB."
+```
+
+---
+
+## Task 3: Issue #4 — prayer time accuracy regression tests
+
+**Branch:** `fix/issue-4-prayer-accuracy-regression-tests`
+
+**Files:**
+- Create: `Tests/PrayerAccuracyRegressionTests.swift`
+- Modify: `iqamah.xcodeproj/project.pbxproj` — add new file to `iqamahTests` target
+
+**Reference values (2024-01-15, MWL, Standard Asr, ±3 min tolerance):**
+
+| City     | Lat       | Lon        | TZ              | UTC | Fajr | Dhuhr | Asr  | Maghrib | Isha |
+|----------|-----------|------------|-----------------|-----|------|-------|------|---------|------|
+| Makkah   | 21.4225   | 39.8262    | Asia/Riyadh     | +3  | 5:22 | 12:20 | 3:36 | 6:01    | 7:31 |
+| New York | 40.7128   | -74.006    | America/New_York| -5  | 6:05 | 12:11 | 2:44 | 4:50    | 6:16 |
+| London   | 51.5074   | -0.1278    | Europe/London   | +0  | 6:17 | 12:11 | 2:02 | 4:09    | 5:52 |
+| Jakarta  | -6.2088   | 106.8456   | Asia/Jakarta    | +7  | 4:12 | 11:56 | 3:13 | 6:01    | 7:13 |
+| Toronto  | 43.6532   | -79.3832   | America/Toronto | -5  | 6:12 | 12:16 | 2:50 | 4:57    | 6:22 |
+
+**PBX IDs to use** (continuing the existing EE00... sequence):
+- `EE0000000000000000001011` — file reference
+- `EE0000000000000000001012` — build file
+
+- [ ] **Step 1: Branch off develop**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+git checkout develop
+git pull origin develop
+git checkout -b fix/issue-4-prayer-accuracy-regression-tests
+```
+
+- [ ] **Step 2: Create `Tests/PrayerAccuracyRegressionTests.swift`**
+
+```swift
+import Testing
+import Foundation
+import CoreLocation
+
+@Suite("Prayer Time Accuracy Regression Tests")
+struct PrayerAccuracyRegressionTests {
+
+    // Fixed reference date: 2024-01-15
+    // All DateComponents include timeZone explicitly so CI runners on UTC
+    // produce the same local-time breakdown as a developer's machine.
+    private static func referenceDate(in tz: TimeZone) -> Date {
+        var c = DateComponents()
+        c.timeZone = tz
+        c.year = 2024
+        c.month = 1
+        c.day = 15
+        c.hour = 12
+        c.minute = 0
+        c.second = 0
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    // Returns hour and minute of a Date interpreted in the given timezone.
+    private func hm(_ date: Date, in tz: TimeZone) -> (Int, Int) {
+        let comps = Calendar(identifier: .gregorian)
+            .dateComponents(in: tz, from: date)
+        return (comps.hour!, comps.minute!)
+    }
+
+    // Asserts prayer time is within ±3 minutes of reference (h, m).
+    private func assertWithin3Min(
+        _ actual: Date,
+        expected: (h: Int, m: Int),
+        in tz: TimeZone,
+        label: String,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        let (ah, am) = hm(actual, in: tz)
+        let actualMin = ah * 60 + am
+        let expectedMin = expected.h * 60 + expected.m
+        let diff = abs(actualMin - expectedMin)
+        #expect(
+            diff <= 3,
+            "\(label): expected \(expected.h):\(String(format: "%02d", expected.m)), "
+            + "got \(ah):\(String(format: "%02d", am)) (diff \(diff) min)",
+            sourceLocation: sourceLocation
+        )
+    }
+
+    // MARK: - Makkah
+
+    @Test("Makkah (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func makkahAccuracy() throws {
+        let tz = TimeZone(identifier: "Asia/Riyadh")!
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: 21.4225, longitude: 39.8262),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr,    expected: (5, 22), in: tz, label: "Makkah Fajr")
+        assertWithin3Min(times.dhuhr,   expected: (12, 20), in: tz, label: "Makkah Dhuhr")
+        assertWithin3Min(times.asr,     expected: (15, 36), in: tz, label: "Makkah Asr")
+        assertWithin3Min(times.maghrib, expected: (18,  1), in: tz, label: "Makkah Maghrib")
+        assertWithin3Min(times.isha,    expected: (19, 31), in: tz, label: "Makkah Isha")
+    }
+
+    // MARK: - New York
+
+    @Test("New York (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func newYorkAccuracy() throws {
+        let tz = TimeZone(identifier: "America/New_York")!
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.006),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr,    expected: (6,  5), in: tz, label: "New York Fajr")
+        assertWithin3Min(times.dhuhr,   expected: (12, 11), in: tz, label: "New York Dhuhr")
+        assertWithin3Min(times.asr,     expected: (14, 44), in: tz, label: "New York Asr")
+        assertWithin3Min(times.maghrib, expected: (16, 50), in: tz, label: "New York Maghrib")
+        assertWithin3Min(times.isha,    expected: (18, 16), in: tz, label: "New York Isha")
+    }
+
+    // MARK: - London
+
+    @Test("London (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func londonAccuracy() throws {
+        let tz = TimeZone(identifier: "Europe/London")!
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: 51.5074, longitude: -0.1278),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr,    expected: (6, 17), in: tz, label: "London Fajr")
+        assertWithin3Min(times.dhuhr,   expected: (12, 11), in: tz, label: "London Dhuhr")
+        assertWithin3Min(times.asr,     expected: (14,  2), in: tz, label: "London Asr")
+        assertWithin3Min(times.maghrib, expected: (16,  9), in: tz, label: "London Maghrib")
+        assertWithin3Min(times.isha,    expected: (17, 52), in: tz, label: "London Isha")
+    }
+
+    // MARK: - Jakarta
+
+    @Test("Jakarta (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func jakartaAccuracy() throws {
+        let tz = TimeZone(identifier: "Asia/Jakarta")!
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: -6.2088, longitude: 106.8456),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr,    expected: (4, 12), in: tz, label: "Jakarta Fajr")
+        assertWithin3Min(times.dhuhr,   expected: (11, 56), in: tz, label: "Jakarta Dhuhr")
+        assertWithin3Min(times.asr,     expected: (15, 13), in: tz, label: "Jakarta Asr")
+        assertWithin3Min(times.maghrib, expected: (18,  1), in: tz, label: "Jakarta Maghrib")
+        assertWithin3Min(times.isha,    expected: (19, 13), in: tz, label: "Jakarta Isha")
+    }
+
+    // MARK: - Toronto
+
+    @Test("Toronto (MWL, 2024-01-15) prayer times within ±3 min of reference")
+    func torontoAccuracy() throws {
+        let tz = TimeZone(identifier: "America/Toronto")!
+        let calculator = PrayerCalculator(
+            coordinate: CLLocationCoordinate2D(latitude: 43.6532, longitude: -79.3832),
+            timezone: tz,
+            method: .muslimWorldLeague,
+            asrMethod: .standard
+        )
+        let times = try calculator.calculate(for: Self.referenceDate(in: tz))
+
+        assertWithin3Min(times.fajr,    expected: (6, 12), in: tz, label: "Toronto Fajr")
+        assertWithin3Min(times.dhuhr,   expected: (12, 16), in: tz, label: "Toronto Dhuhr")
+        assertWithin3Min(times.asr,     expected: (14, 50), in: tz, label: "Toronto Asr")
+        assertWithin3Min(times.maghrib, expected: (16, 57), in: tz, label: "Toronto Maghrib")
+        assertWithin3Min(times.isha,    expected: (18, 22), in: tz, label: "Toronto Isha")
+    }
+}
+```
+
+**Note on reference values:** The reference times from the issue spec use 12-hour clock (e.g. "3:36" for Asr, "6:01" for Maghrib). These are PM times. In 24h: Asr = 15:36, Maghrib = 18:01, Isha = 19:31. The code above already converts to 24h.
+
+- [ ] **Step 3: Add file reference and build file to `iqamah.xcodeproj/project.pbxproj`**
+
+In `iqamah.xcodeproj/project.pbxproj`, make three edits:
+
+**Edit A — Add PBXBuildFile entry** (in the `/* Begin PBXBuildFile section */` block, after the IntegrationAndEdgeCaseTests line):
+
+Find:
+```
+		EE0000000000000000001010 /* IntegrationAndEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE000000000000000000100F /* IntegrationAndEdgeCaseTests.swift */; };
+```
+
+Add after it:
+```
+		EE0000000000000000001012 /* PrayerAccuracyRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0000000000000000001011 /* PrayerAccuracyRegressionTests.swift */; };
+```
+
+**Edit B — Add PBXFileReference entry** (in `/* Begin PBXFileReference section */`, after the IntegrationAndEdgeCaseTests line):
+
+Find:
+```
+		EE000000000000000000100F /* IntegrationAndEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationAndEdgeCaseTests.swift; sourceTree = "<group>"; };
+```
+
+Add after it:
+```
+		EE0000000000000000001011 /* PrayerAccuracyRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerAccuracyRegressionTests.swift; sourceTree = "<group>"; };
+```
+
+**Edit C — Add to PBXGroup** (in the Tests group children array):
+
+Find:
+```
+			EE000000000000000000100F /* IntegrationAndEdgeCaseTests.swift */,
+```
+
+Add after it:
+```
+			EE0000000000000000001011 /* PrayerAccuracyRegressionTests.swift */,
+```
+
+**Edit D — Add to Sources build phase** (in the iqamahTests sources build phase array):
+
+Find:
+```
+				EE0000000000000000001010 /* IntegrationAndEdgeCaseTests.swift in Sources */,
+```
+
+Add after it:
+```
+				EE0000000000000000001012 /* PrayerAccuracyRegressionTests.swift in Sources */,
+```
+
+- [ ] **Step 4: Build locally to confirm project compiles**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+for name in adhaan_1 adhaan_2 adhaan_3 adhaan_4 adhaan_5 adhaan_fajr_1 adhaan_fajr_2 adhaan_fajr_3; do
+  touch "iqamah/Resources/${name}.mp3"
+done
+xcodebuild \
+  -project iqamah.xcodeproj \
+  -scheme iqamah \
+  -configuration Debug \
+  -destination 'platform=macOS' \
+  build \
+  CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+```
+
+Expected: `BUILD SUCCEEDED`
+
+- [ ] **Step 5: Run the new tests locally**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+xcodebuild \
+  -project iqamah.xcodeproj \
+  -scheme iqamah \
+  -configuration Debug \
+  -destination 'platform=macOS' \
+  -only-testing:iqamahTests/PrayerAccuracyRegressionTests \
+  test \
+  CODE_SIGNING_ALLOWED=NO 2>&1 | grep -E "Test Suite|PASS|FAIL|error:"
+```
+
+Expected: all 5 test cases pass. If a test fails with diff > 3 min, check the expected value conversion (12h → 24h); adjust in the Swift file, not by widening the tolerance.
+
+- [ ] **Step 6: Run swiftlint and swiftformat**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+swiftformat Tests/PrayerAccuracyRegressionTests.swift --config .swiftformat 2>/dev/null || true
+swiftlint lint Tests/PrayerAccuracyRegressionTests.swift --strict 2>/dev/null || true
+```
+
+Fix any violations before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/Kamal_Syed/Projects/iqamah/iqamah
+git add Tests/PrayerAccuracyRegressionTests.swift iqamah.xcodeproj/project.pbxproj
+git commit -m "test: add prayer time accuracy regression test suite
+
+Adds PrayerAccuracyRegressionTests covering 5 reference cities
+(Makkah, New York, London, Jakarta, Toronto) on 2024-01-15 with
+the MWL method. Asserts each prayer time is within ±3 minutes
+of reference values from IslamicFinder. All DateComponents
+specify timeZone explicitly to avoid UTC drift on CI runners.
+
+Closes #4"
+```
+
+- [ ] **Step 8: Push and open PR**
+
+```bash
+git push origin fix/issue-4-prayer-accuracy-regression-tests
+gh pr create \
+  --title "test: add prayer time accuracy regression test suite" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `Tests/PrayerAccuracyRegressionTests.swift` to the `iqamahTests` target
+- 5 reference cities × 5 prayers = 25 assertions on a fixed date (2024-01-15, MWL)
+- Tolerance: ±3 minutes per prayer
+- All `DateComponents` include `timeZone` explicitly to prevent UTC drift on CI runners
+- `project.pbxproj` updated with new file reference and build file entries
+
+## Test plan
+- [ ] All 5 test cases pass locally: `xcodebuild test -only-testing:iqamahTests/PrayerAccuracyRegressionTests`
+- [ ] CI test job passes
+
+Closes #4
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" \
+  --base develop \
+  --repo ksyed0/iqamah
+```
+
+- [ ] **Step 9: Wait for CI green, merge, close issue**
+
+```bash
+gh pr checks --watch --repo ksyed0/iqamah
+gh pr merge --squash --repo ksyed0/iqamah
+gh issue close 4 --repo ksyed0/iqamah --comment "Fixed: PrayerAccuracyRegressionTests.swift added covering 5 cities × 5 prayers on 2024-01-15 (MWL, ±3 min tolerance)."
+```
+
+---
+
+## Task 4: Update docs after all merges
+
+**Branch:** `docs/issue-4-5-6-postmerge`
+*(Can be done on `develop` directly if branch protection allows, otherwise a PR)*
+
+**Files:**
+- Modify: `docs/BUGS.md` — add/update CI and test entries
+- Modify: `docs/RELEASE_PLAN.md` — mark CI items as done
+
+- [ ] **Step 1: Update `docs/BUGS.md`**
+
+Add a section noting the resolved CI issues:
+
+```markdown
+## Resolved (this sprint)
+
+**BUG-CI-005: cities.json validation not path-filtered**
+- **Severity:** Low / maintenance
+- **Resolution:** Added `validate-cities.yml` workflow with `paths:` filter (Issue #5)
+- **Resolved:** 2026-05-03
+
+**BUG-CI-006: File size guard checked repo files, not .app bundle**
+- **Severity:** Medium
+- **Resolution:** Replaced file-size job with Release build + `du -sm` bundle check, 50 MB limit (Issue #6)
+- **Resolved:** 2026-05-03
+
+**BUG-TEST-004: No prayer time accuracy regression tests**
+- **Severity:** High
+- **Resolution:** Added PrayerAccuracyRegressionTests.swift, 5 cities × 5 prayers, ±3 min tolerance (Issue #4)
+- **Resolved:** 2026-05-03
+```
+
+- [ ] **Step 2: Update `docs/RELEASE_PLAN.md`**
+
+Under the CI/quality section, mark the three items as completed.
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add docs/BUGS.md docs/RELEASE_PLAN.md
+git commit -m "docs: record resolution of issues #4, #5, #6"
+git push origin docs/issue-4-5-6-postmerge
+gh pr create --title "docs: record resolution of issues #4, #5, #6" --body "Post-merge doc update." --base develop --repo ksyed0/iqamah
+gh pr merge --squash --repo ksyed0/iqamah
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ Issue #5: validate_cities.py exists; CI job + path filter via dedicated workflow
+- ✅ Issue #6: Release build + du -sm + 50 MB limit + prints size on success
+- ✅ Issue #4: 5 cities, 2024-01-15, MWL, ±3 min, explicit timeZone, pbxproj updated
+
+**Placeholder scan:** No TBDs or deferred steps found.
+
+**Type consistency:**
+- `PrayerCalculator.init(coordinate:timezone:method:asrMethod:)` matches existing constructor in `PrayerCalculator.swift`
+- `PrayerTimes.fajr`, `.dhuhr`, `.asr`, `.maghrib`, `.isha` match existing struct fields
+- `CalculationMethod.muslimWorldLeague` matches existing enum case
+- `AsrJuristicMethod.standard` matches existing enum case
+- PBX IDs `EE0000000000000000001011/1012` are unused (verified against pbxproj grep)


### PR DESCRIPTION
## Summary

Two doc-only updates from the v1.6.0 (15) pre-submission audit, bundled together because both came from the same multi-platform test suite run.

### ENH-0028 — Add watchOS test target to IqamahWatch scheme
The IqamahWatch xcodebuild scheme has no XCTest bundle. `xcodebuild test -scheme IqamahWatch` reports 0 tests. Watch confidence today comes indirectly from IqamahCore unit tests and successful compilation. Watch-specific code (Watch Connectivity, complications, watch-only UI) has zero automated coverage.

### ENH-0029 — Add iOS-specific unit test target to iqamah-iOS scheme
The iqamah-iOS scheme runs only `IqamahiOSUITests` (8 UI tests, ~9 min wall time). No `iqamah-iOSTests` unit test bundle exists. iOS-specific runtime code (UIKit lifecycle, BGAppRefreshTask, NotificationScheduler extensions, iOS-only views) has no fast unit coverage.

Both filed as Medium priority — gaps not blockers. v1.6.0 (15) is shippable today; these are future test-coverage epics.

### Plus: archive 2026-05-03 implementation plan
Found a 701-line plan doc (`docs/superpowers/plans/2026-05-03-close-issues-4-5-6.md`) sitting untracked in the primary checkout. The plan was executed at the time (closing GitHub issues #4/#5/#6) but the doc was never committed. Archiving it for posterity.

## Files

- `docs/ENHANCEMENTS.md` — new 'Testing & Quality Infrastructure' section with 2 entries (+~60 lines)
- `docs/ID_REGISTRY.md` — bump ENH row to next=ENH-0030/last=ENH-0029
- `docs/superpowers/plans/2026-05-03-close-issues-4-5-6.md` — new (701 lines, archived plan)

Pure doc PR. Zero code touched. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)