### PR TITLE
docs(app-store): v1.6.0 (15) submission copy + archive instructions

### DIFF
--- a/docs/app-store/v1.6.0-build15/README.md
+++ b/docs/app-store/v1.6.0-build15/README.md
@@ -1,0 +1,46 @@
+# App Store Connect copy — Iqamah v1.6.0 (15)
+
+This directory holds the marketing copy and submission instructions for the v1.6.0 (15) App Store submission. The text is written once here and pasted into App Store Connect — keeping it in the repo means it's reviewable, diffable, and tracked alongside the code release it describes.
+
+## Structure
+
+```
+v1.6.0-build15/
+├── README.md                    ← this file
+├── archive-instructions.md      ← step-by-step Xcode archive + upload guide
+├── ios/
+│   ├── promotion-text.txt        ← 170-char-max blurb shown above the description
+│   ├── whats-new.md              ← "What's New in This Version" (paste verbatim)
+│   └── description.md            ← full app description (paste verbatim or merge with existing)
+└── macos/
+    ├── promotion-text.txt
+    ├── whats-new.md
+    └── description.md
+```
+
+## Why separate iOS and macOS copy
+
+App Store Connect treats iOS and macOS as separate **platform listings** under the same app record (since Iqamah is configured as a Universal Purchase). Each platform has independent Promotion Text, What's New, Description, and screenshot fields.
+
+We **could** use identical copy on both platforms, but the differentiating UI surfaces are different:
+
+- **iOS** leads with Dynamic Island / Live Activity, Apple Watch companion, and lock-screen widgets.
+- **macOS** leads with the always-visible menu bar countdown, Start-on-Login, and Notification Center widgets.
+
+Both versions cover Fasting Mode equally — only the delivery surface in the headline differs.
+
+## How to use these files
+
+1. Open [App Store Connect](https://appstoreconnect.apple.com) → Iqamah → Version 1.6.0
+2. Switch between the iOS and macOS platform tabs at the top of the app page
+3. For each platform:
+   - Paste `promotion-text.txt` into the **Promotional Text** field
+   - Paste `whats-new.md` (rendered as plain text) into **What's New in This Version**
+   - Paste `description.md` (rendered as plain text) into **Description**
+4. Capture and upload screenshots (the one piece this folder cannot generate — see notes in `archive-instructions.md`)
+
+## When to update this copy
+
+- **Promotion Text** can be updated without a new build submission (App Store Connect → Promotional Text field → Save). Useful for tweaking the listing without a binary update.
+- **What's New** must be edited as part of a new version submission — once the version is released, it's frozen for that build.
+- **Description** can also be updated independently of a build (App Store Connect → App Information → Description), but typically you'd refresh it alongside a major release.

--- a/docs/app-store/v1.6.0-build15/archive-instructions.md
+++ b/docs/app-store/v1.6.0-build15/archive-instructions.md
@@ -1,0 +1,122 @@
+# Archiving v1.6.0 (15) to App Store Connect
+
+Step-by-step guide for the v1.6.0 build 15 submission. You'll do this in **two passes** — one iOS archive (bundles iPhone + iPad + Apple Watch + widgets + Live Activity) and one macOS archive — even though Iqamah ships across four build targets. App Store Connect treats iOS and macOS as separate platform listings under the same Universal Purchase record.
+
+## Pre-flight (5 min, do once)
+
+1. **Sync local main:**
+   ```bash
+   cd ~/Projects/iqamah/iqamah
+   git checkout main
+   git pull origin main
+   ```
+2. **Open the project in Xcode:**
+   ```bash
+   open iqamah.xcodeproj
+   ```
+3. **Confirm Xcode is signed in**: Xcode → Settings → Accounts → Apple ID should show your developer team (`96Y29SP9JR` per project config).
+4. **Sanity-check version numbers**: select each target → General → Identity. Should show **Version 1.6.0, Build 15** for:
+   - `iqamah` (macOS app)
+   - `iqamah-iOS` (iOS app)
+   - `IqamahWatch` (watchOS app)
+   - `IqamahWidget` (iOS widget extension)
+   - `IqamahWidgetMac` (macOS widget extension)
+   - `IqamahLiveActivity` (iOS Live Activity extension)
+   - `IqamahWatchWidget` (watchOS widget extension)
+
+   If any are out of sync, abort and check `CURRENT_PROJECT_VERSION = 15` and `MARKETING_VERSION = 1.6.0` in the pbxproj for that target's build settings.
+
+## Pass 1 — iOS submission
+
+Bundles iPhone, iPad, Apple Watch companion, widgets, and Live Activity into a single archive.
+
+1. **Scheme**: dropdown next to Run/Stop button → **iqamah-iOS**
+2. **Destination**: dropdown next to scheme → **Any iOS Device (arm64)**
+   — NOT a simulator.
+3. **Archive**: Product menu → **Archive** (or Cmd+Shift+B then Product → Archive). Xcode builds in Release configuration with code signing. Takes 3–5 min.
+4. **Organizer window** opens automatically with the new archive selected:
+   - Click **Validate App**
+   - Select **App Store Connect** distribution
+   - Choose **Automatically manage signing**
+   - Wait for validation (~1 min)
+   - If issues are reported, fix them and re-archive. The Privacy Manifest we shipped in PR #149 should prevent the most common rejection class (`ITMS-91070`).
+5. If validation passes, click **Distribute App**:
+   - Select **App Store Connect** → **Upload**
+   - Same signing options
+   - Wait for upload (~3–5 min depending on connection)
+6. Once upload completes, the build will show as **Processing** in App Store Connect. Apple takes 10–30 min to process before it's available for TestFlight or for submission to review.
+
+## Pass 2 — macOS submission
+
+Bundles the Mac app + Mac widget extension.
+
+1. **Scheme**: dropdown → **iqamah**
+2. **Destination**: **Any Mac (Apple Silicon, Intel)** or **My Mac** (either works — the archive itself is universal).
+3. **Product → Archive** — same flow as iOS. Takes 2–4 min.
+4. **Organizer** → **Validate App** → **App Store Connect** → automatic signing.
+5. If valid, **Distribute App** → **App Store Connect** → Upload.
+
+## After both uploads complete
+
+1. Open **App Store Connect** in a browser: https://appstoreconnect.apple.com
+2. **Apps → Iqamah** → confirm both platform listings exist (iOS and macOS tabs at the top of the app page)
+3. For each platform's listing:
+   - **Build**: pick the just-uploaded 1.6.0 (15) build (will appear once Apple finishes processing)
+   - **Promotion Text**: paste from `ios/promotion-text.txt` or `macos/promotion-text.txt`
+   - **What's New in This Version**: paste from `ios/whats-new.md` or `macos/whats-new.md`
+   - **Description**: paste from `ios/description.md` or `macos/description.md` (or merge with your existing description)
+   - **Screenshots**: ⚠️ **the one thing this folder can't generate** — see "Screenshots" section below
+   - **Privacy** section: confirm no new data-collection categories (we haven't added any — still no analytics, no servers)
+4. **Submit for Review** — pick **Manual release** if you want to control the release date, **Automatic** if you want it to go live as soon as Apple approves.
+
+## Screenshots
+
+Apple requires up-to-date screenshots that reflect the current app state. Since Fasting Mode is the headline new feature, capture at least:
+
+- **Main popover with Fasting Mode banner active** (Ramadan purple gradient, with Suhoor + Iftar times visible)
+- **Fasting Mode settings sheet** (master toggle on, several triggers enabled)
+- **iOS hero card** in active Ramadan state
+- **Apple Watch prayer-times tab** with Fasting Mode indicator
+- **Widget gallery** showing the fasting-aware variants
+
+Required sizes (per Apple's current requirements):
+
+| Platform | Required size | Notes |
+|----------|---------------|-------|
+| iPhone 6.9" (iPhone 17 Pro Max) | 1320 × 2868 | Primary iOS marketing size |
+| iPhone 6.5" (iPhone 11 Pro Max) | 1242 × 2688 | Legacy, still required by some apps |
+| iPad Pro 13" | 2064 × 2752 | For iPad listing |
+| macOS | 1280 × 800 minimum, up to 2880 × 1800 | Use at least 2× retina |
+| Apple Watch | 410 × 502 (41mm), 416 × 496 (46mm) | Per the watch sizes in your support matrix |
+
+Best workflow:
+1. Open the appropriate simulator (Xcode → Open Developer Tool → Simulator)
+2. Set the device, pose the app in the desired state
+3. ⌘S (or Device → Screenshot in the simulator menu) to capture to Desktop
+4. Drag the resulting PNG into App Store Connect's screenshot uploader
+
+## After submission
+
+- iOS reviews typically take 24–48 hours (sometimes faster)
+- macOS reviews usually similar; occasionally slower
+- App Store Connect emails you on every state change
+
+## Rejection-risk checklist (already addressed)
+
+The technical-rejection risks we've actively prevented going into this submission:
+
+- ✅ **Privacy Manifest** declared for all 7 targets (PR #149) — avoids `ITMS-91070` and related auto-rejections
+- ✅ **CFBundleVersion** atomic at 15 across parent app + every extension (PR #134) — avoids `ITMS-90362` extension-version-mismatch rejections
+- ✅ **Watch icon** has a non-black background (accepted in v1.5 build 15) — avoids the Guideline 4 design rejection we hit in v1.5 build 13
+- ✅ **No new permission types** or background modes that trigger manual review
+- ✅ **Time-sensitive notifications** properly declared; no Critical Alerts entitlement required (avoids manual entitlement review)
+
+## If review rejects
+
+Read the rejection carefully — most rejections at this point would be cosmetic (screenshot mismatch, description issue) rather than technical. Apple's review feedback typically includes:
+
+- Specific guideline number violated
+- Steps to reproduce the issue (for behavioral problems)
+- Screenshots or video evidence (for visual problems)
+
+Apple Reviewer team responses can be replied to via Resolution Center in App Store Connect — substantive responses (e.g., "this is intentional because…") often help resolve issues without re-submitting.

--- a/docs/app-store/v1.6.0-build15/ios/description.md
+++ b/docs/app-store/v1.6.0-build15/ios/description.md
@@ -1,0 +1,48 @@
+Iqamah is a beautifully minimal prayer-times companion for your iPhone, iPad, and Apple Watch. Accurate prayer times for any city in the world, with seamless native integrations — Dynamic Island, Live Activities, complications, widgets — that keep you in rhythm with your day, wherever you are.
+
+PRAYER TIMES
+• Six calculation methods: Muslim World League, ISNA, Egyptian General Authority, Umm al-Qura, Karachi, Tehran (Jafari)
+• Hanafi or Standard Asr jurisprudence
+• Per-prayer minute adjustments
+• Accurate worldwide via a cities database with proper timezone handling
+• Time-sensitive notifications that respect Focus modes without bypassing Do Not Disturb
+
+🌙 FASTING MODE (new in 1.6.0)
+• Automatic Ramadan detection
+• Weekly sunnah days, Ayyam al-Beed, Six of Shawwal, Day of Arafah, first 9 of Dhul-Hijjah, Tasu'a, Ashura
+• Mid-Sha'ban and 27 Rajab for Shia communities
+• Customizable Suhoor and Iftar reminders
+• Beautiful Live Activity countdown in the Dynamic Island
+
+ALWAYS-VISIBLE NEXT PRAYER
+• Live Activity & Dynamic Island show your next prayer and Suhoor / Iftar countdowns all day
+• Lock-screen widget — glance at your wrist or phone without unlocking
+• Home-screen widgets in every size, with adaptive layouts for iPhone and iPad
+• Time-sensitive notifications break through Focus modes when you need them
+
+APPLE WATCH COMPANION
+• Native watchOS app with prayer-times tab and qibla compass
+• Hilal sighting helper for moon-spotting on the 29th of each Hijri month
+• Widget complications for every watch face — circular, corner, inline, modular
+• Standalone settings; works without your iPhone nearby
+
+HIJRI CALENDAR & MOON
+• Hijri date everywhere
+• Moon-phase glyph that updates daily
+• Astronomically accurate calculations
+
+QIBLA COMPASS
+• Real-time direction to the Kaaba
+• Accuracy within a fraction of a degree
+
+iCLOUD SYNC
+• Change your settings on iPhone, see them on iPad and Apple Watch instantly
+• No account, no login — uses your existing iCloud
+
+PRIVACY-FIRST
+• 100% on-device computation — no servers, no analytics, no tracking
+• Location used only for prayer-time calculation; never transmitted
+• No account required
+• Free. Free of ads. Free of ulterior motives.
+
+Iqamah is built and maintained by a single developer who wanted a prayer-times app that felt like it belonged on Apple platforms — quiet, beautiful, accurate, and respectful of your attention.

--- a/docs/app-store/v1.6.0-build15/ios/promotion-text.txt
+++ b/docs/app-store/v1.6.0-build15/ios/promotion-text.txt
@@ -1,0 +1,1 @@
+Now with Fasting Mode 🌙 — Suhoor & Iftar countdowns in your Dynamic Island, plus automatic Ramadan, weekly sunnah days, and so much more.

--- a/docs/app-store/v1.6.0-build15/ios/whats-new.md
+++ b/docs/app-store/v1.6.0-build15/ios/whats-new.md
@@ -1,0 +1,26 @@
+🌙 Fasting Mode arrives in your pocket and on your wrist.
+
+Comprehensive support for Islamic fasting traditions, with a beautiful Live Activity that keeps your Suhoor and Iftar countdowns in the Dynamic Island all day.
+
+• Automatic Ramadan detection from the Hijri calendar
+• Weekly sunnah fasts (Monday and/or Thursday)
+• Ayyam al-Beed — the 13th, 14th, 15th of every Hijri month
+• Six days of Shawwal, Day of Arafah, first 9 of Dhul-Hijjah, Tasu'a, Ashura
+• Shia-specific observances: 15 Sha'ban, 27 Rajab
+• Aware of prohibited fasting days (Eid al-Fitr, Eid al-Adha, Tashriq)
+
+Customizable reminders:
+• Suhoor reminder — 5 to 120 minutes before Fajr
+• Iftar reminder — 5 to 120 minutes before Maghrib
+• Optional day-before reminder at the time you choose
+
+Right on your wrist: the Apple Watch app shows your fasting status on the prayer-times tab, with widget complications you can place on any watch face.
+
+Other improvements in 1.6.0:
+• Smarter location detection — sees your actual neighborhood, not just the nearest big city. Opt-in 25 km auto-detect prompts when you travel.
+• Live Activity correctly advances past a passed prayer (no more stuck "Maghrib" hours after sunset).
+• Many small polish improvements.
+
+Known limitation: if iOS suspends the app for several hours, the Dynamic Island may briefly show a passed prayer until you reopen Iqamah. Notifications continue to fire normally.
+
+As always — free, ad-free, privacy-first. No tracking, no analytics, no account. All computation on your device.

--- a/docs/app-store/v1.6.0-build15/macos/description.md
+++ b/docs/app-store/v1.6.0-build15/macos/description.md
@@ -1,0 +1,42 @@
+Iqamah is a beautifully minimal prayer-times companion for your Mac. A quiet countdown to your next prayer lives in your menu bar — always visible, never in the way. Open the popover for the full day's times, or use widgets in Notification Center for an even quicker glance.
+
+PRAYER TIMES
+• Six calculation methods: Muslim World League, ISNA, Egyptian General Authority, Umm al-Qura, Karachi, Tehran (Jafari)
+• Hanafi or Standard Asr jurisprudence
+• Per-prayer minute adjustments
+• Accurate worldwide via a cities database with proper timezone handling
+
+🌙 FASTING MODE (new in 1.6.0)
+• Automatic Ramadan detection
+• Weekly sunnah days, Ayyam al-Beed, Six of Shawwal, Day of Arafah, first 9 of Dhul-Hijjah, Tasu'a, Ashura
+• Mid-Sha'ban and 27 Rajab for Shia communities
+• Customizable Suhoor and Iftar reminders
+• Fasting status visible in the menu-bar dropdown
+
+LIVES QUIETLY IN YOUR MENU BAR
+• Always-visible countdown to your next prayer
+• Click for a beautiful popover with the full day's times, Hijri date, moon phase, and qibla direction
+• Start-on-Login so Iqamah is ready as soon as you boot
+• Notification Center widgets for an even quicker glance
+• Time-sensitive notifications that respect Focus modes without bypassing Do Not Disturb
+
+HIJRI CALENDAR & MOON
+• Hijri date in the menu bar and the popover
+• Moon-phase glyph that updates daily
+• Astronomically accurate calculations
+
+QIBLA COMPASS
+• Real-time direction to the Kaaba
+• Accuracy within a fraction of a degree
+
+iCLOUD SYNC
+• Change your settings on your iPhone, see them on your Mac instantly
+• No account, no login — uses your existing iCloud
+
+PRIVACY-FIRST
+• 100% on-device computation — no servers, no analytics, no tracking
+• Location used only for prayer-time calculation; never transmitted
+• No account required
+• Free. Free of ads. Free of ulterior motives.
+
+Iqamah is built and maintained by a single developer who wanted a Mac prayer-times app that felt like a first-class Apple citizen — quiet, beautiful, accurate, and respectful of your attention.

--- a/docs/app-store/v1.6.0-build15/macos/promotion-text.txt
+++ b/docs/app-store/v1.6.0-build15/macos/promotion-text.txt
@@ -1,0 +1,1 @@
+Now with Fasting Mode 🌙 — a quiet Suhoor & Iftar countdown right in your menu bar, plus automatic Ramadan and sunnah day reminders.

--- a/docs/app-store/v1.6.0-build15/macos/whats-new.md
+++ b/docs/app-store/v1.6.0-build15/macos/whats-new.md
@@ -1,0 +1,25 @@
+🌙 Fasting Mode for your Mac.
+
+Comprehensive support for Islamic fasting traditions, with a glanceable status that lives quietly in your menu bar — never in the way while you work.
+
+• Automatic Ramadan detection from the Hijri calendar
+• Weekly sunnah fasts (Monday and/or Thursday)
+• Ayyam al-Beed — the 13th, 14th, 15th of every Hijri month
+• Six days of Shawwal, Day of Arafah, first 9 of Dhul-Hijjah, Tasu'a, Ashura
+• Shia-specific observances: 15 Sha'ban, 27 Rajab
+• Aware of prohibited fasting days (Eid al-Fitr, Eid al-Adha, Tashriq)
+
+Customizable reminders:
+• Suhoor reminder — 5 to 120 minutes before Fajr
+• Iftar reminder — 5 to 120 minutes before Maghrib
+• Optional day-before reminder at the time you choose
+
+The menu-bar dropdown now shows your fasting status alongside today's prayer times. The adhaan notification panel now anchors under your Iqamah menu-bar icon, where you'd expect it to come from.
+
+Other improvements in 1.6.0:
+• Smarter location detection — sees your actual neighborhood, not just the nearest big city. Opt-in 25 km auto-detect prompts when you've moved.
+• Start-on-Login now reliably keeps Iqamah running across reboots.
+• Top-bar buttons in the main window now have helpful labels (Qiblah, Settings, About, Mute).
+• Many small polish improvements.
+
+As always — free, ad-free, privacy-first. No tracking, no analytics, no account. All computation on your Mac, never transmitted.


### PR DESCRIPTION
## Summary

Adds \`docs/app-store/v1.6.0-build15/\` containing all the App Store Connect marketing copy + a step-by-step archive/upload guide for the v1.6.0 (15) submission.

## Why in the repo

- Marketing copy is reviewable, diffable, and tracked alongside the code release it describes
- Future versions can iterate by copying the directory
- Archive instructions capture the exact Xcode + App Store Connect flow so it's not re-derived from memory each release

## Structure

\`\`\`
docs/app-store/v1.6.0-build15/
├── README.md                  ← overview, how to use these files
├── archive-instructions.md    ← step-by-step Xcode archive + upload guide
├── ios/
│   ├── promotion-text.txt     ← 170-char-max blurb (Dynamic Island headline)
│   ├── whats-new.md           ← What's New copy (leads with Live Activity story)
│   └── description.md         ← full description (Dynamic Island + Apple Watch + lock-screen widgets emphasis)
└── macos/
    ├── promotion-text.txt     ← (menu-bar headline)
    ├── whats-new.md           ← (leads with menu-bar status)
    └── description.md         ← (always-visible-while-you-work emphasis)
\`\`\`

## Why separate iOS and macOS copy

App Store Connect treats iOS and macOS as separate platform listings under the same Universal Purchase app record. We *could* use identical copy on both, but the differentiating UI surfaces are different:

- **iOS** leads with Dynamic Island / Live Activity, Apple Watch companion, lock-screen widgets
- **macOS** leads with always-visible menu bar countdown, Start-on-Login, Notification Center widgets

Fasting Mode coverage is identical on both. Only the headline + first paragraph differs.

## Test plan

- [ ] CI green (doc-only PR; only lint + format checks apply)
- [ ] On submission: paste the copy verbatim into App Store Connect and confirm it fits within field limits (170-char promo text, 4000-char what's-new and description)

Pure docs. Zero code touched. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)