### PR TITLE
fix(pages): exclude developer-only docs from Jekyll/Liquid rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,60 @@
+# GitHub Pages site configuration for Iqamah.
+#
+# Iqamah doesn't run a deliberate Jekyll site — GitHub Pages auto-publishes
+# Markdown rendered with the default theme from the repo root and docs/.
+# This config restricts what gets rendered so developer-only documentation
+# doesn't break the site build.
+#
+# Background: Jekyll renders Markdown through Liquid before passing to the
+# Markdown renderer. Liquid interprets {{ ... }} as variable substitution
+# and {% ... %} as tag invocation. Plan and spec documents in this repo
+# contain pbxproj fragments, shell command examples with bash variable
+# expansion, and Swift template snippets — all of which use brace syntax
+# that breaks Liquid parsing. Rather than wrap every offending snippet in
+# {% raw %} ... {% endraw %} tags (and require every future plan author to
+# remember to do the same), we exclude those directories from the Pages
+# build entirely.
+#
+# What this means in practice:
+#   - The Pages site shows: README, Privacy_Policy, AGENTS, CLAUDE, and the
+#     user-readable docs (BUGS, ENHANCEMENTS, RELEASE_PLAN, etc.) at
+#     docs/*.md and AGE_RATING/APP_STORE_LISTING/etc.
+#   - The Pages site does NOT show: implementation plans, design specs,
+#     App Store Connect copy drafts, plus all source/build/worktree
+#     directories.
+#
+# To add a new exclusion in the future: add the directory to the `exclude`
+# list below. To temporarily render an excluded directory locally, run
+# `bundle exec jekyll serve` without this config.
+
+theme: jekyll-theme-primer
+
+# Directories Jekyll should not process. The default GitHub Pages exclude
+# list already covers vendor/, node_modules/, etc. — we add Iqamah-specific
+# directories that either contain non-content (source code, build
+# artifacts) or Markdown with Liquid-conflicting syntax.
+exclude:
+  # Developer-only docs with Liquid-conflicting syntax (pbxproj fragments,
+  # bash variable expansion, Swift template snippets).
+  - docs/superpowers/
+
+  # App Store Connect copy drafts — meant for paste into App Store Connect,
+  # not for public website rendering.
+  - docs/app-store/
+
+  # Session / worktree / agent metadata.
+  - .claude/
+
+  # Build artifacts and caches.
+  - .build/
+  - build/
+  - Build/
+  - DerivedData/
+
+  # Xcode project file is a directory containing pbxproj XML; Jekyll
+  # shouldn't try to walk into it.
+  - iqamah.xcodeproj/
+
+  # Snapshot test baselines (PNGs, not Markdown — Jekyll ignores them
+  # anyway, but explicit exclusion keeps the build log clean).
+  - Tests/__Snapshots__/


### PR DESCRIPTION
## Summary

GitHub Pages auto-rendering via Jekyll has been failing on every push since the EPIC-0012 watchOS implementation plan landed (commit a88e599). The failure: Liquid template parser chokes on \`{{ ... }}\` Xcode pbxproj fragments embedded in plan docs under \`docs/superpowers/\`.

Specifically — the failure message from \`pages-build-deployment\`:

\`\`\`
Liquid Exception: Liquid syntax error (line 299):
Variable '{{isa = PBXBuildFile; productRef = {IC_PROD_DEP}' was not
properly terminated with regexp: /\\}\\}/
in docs/superpowers/plans/2026-05-10-epic-0012-watchos-implementation.md
\`\`\`

That plan doc has ~25 lines of pbxproj snippets, and other plan/spec docs in the same directory contain similar patterns (shell examples with \`\${VAR}\`, Swift templates, etc.).

## The fix

Add a \`_config.yml\` at the repo root telling Jekyll to skip:

- \`docs/superpowers/\` — implementation plans + design specs (dev-only)
- \`docs/app-store/\` — App Store Connect copy drafts (paste-into-ASC, not public)
- \`.claude/\` — session/worktree/agent metadata
- \`.build/\`, \`build/\`, \`Build/\`, \`DerivedData/\` — build artifacts
- \`iqamah.xcodeproj/\` — pbxproj directory, not Markdown
- \`Tests/__Snapshots__/\` — PNG baselines

## Why root-cause over per-file fix

Alternative: wrap each offending snippet in \`{% raw %}...{% endraw %}\` tags. That works for the immediate failure but every future plan/spec author has to remember to escape. The \`_config.yml\` exclusion makes Jekyll skip those directories entirely — immune to future plan additions.

## What still renders on the Pages site

README, Privacy_Policy, AGENTS, CLAUDE, and the user-readable docs at the top of \`docs/\` (AGE_RATING, APP_ICON_SETUP, APP_STORE_LISTING, BUGS, DEPLOYMENT_READINESS, ENHANCEMENTS, FILE_ORGANIZATION_GUIDE, ID_REGISTRY, LESSONS, MEMORY, MIGRATION_LOG, MVP_COMPLETION_SUMMARY, RELEASE_PLAN, etc.).

## Test plan

- [ ] PR's \`pages-build-deployment\` workflow run goes green for the first time since EPIC-0012 landed
- [ ] After merge, browse https://ksyed0.github.io/iqamah/ to confirm the published site looks correct (README + privacy + user-readable docs render; plan/spec/app-store docs are absent as intended)

## Why this lands on main instead of develop

This is a doc-only hotfix targeting the Pages publishing pipeline. Pages publishes from \`main\` (verified via \`gh api repos/ksyed0/iqamah/pages\`), so the fix has to land there to take effect. Per the Git Flow we just restored (PR #152), code PRs should target \`develop\`; this Pages hotfix is the canonical exception — a one-off fix that needs to be on the published branch to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)